### PR TITLE
Fix syntax error in release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
+
 jobs:
   build:
     runs-on:  ${{ matrix.os }}
     environment: release
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +27,8 @@ jobs:
         pip install -r requirements-dev.txt
         pip install -e .
     - name: Build with hatch
-        hatch build -c 
+      run: |
+        hatch build -c
 
   pypi-publish:
     name: upload release to PyPI


### PR DESCRIPTION
"Build with hatch" step was missing a `run:` block