### PR TITLE
clean up #90 bug fix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,17 +7,17 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.9"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+    os: ubuntu-22.04
+    tools:
+        python: "3.9"
+        # You can also specify other tool versions:
+        # nodejs: "19"
+        # rust: "1.64"
+        # golang: "1.19"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/source/conf.py
+    configuration: docs/source/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
@@ -25,7 +25,7 @@ sphinx:
 
 # Optionally declare the Python requirements required to build your docs
 python:
-   install:
-   - requirements: docs/requirements.txt
-   - method: pip
-     path: .
+    install:
+        - requirements: requirements.txt
+        - method: pip
+          path: .

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,8 +5,8 @@
 SPHINXOPTS    =
 SPHINXBUILD   = python -m sphinx
 SPHINXPROJ    = dysh
-SOURCEDIR     = .
-BUILDDIR      = _build
+SOURCEDIR     = ./source
+BUILDDIR      = ./_build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ sphinx_rtd_theme
 sphinxcontrib_mermaid
 myst_parser
 numpydoc
+-e .
 
 # Toolkit
 wget


### PR DESCRIPTION
Changes to fix the bug reported in issue https://github.com/GreenBankObservatory/dysh/issues/90. It was mainly just fixing paths in the .readthedocs.yaml file. Requirements.txt file also had some dependency issues for Python 3.8 that I resolved. Docs now build with the same hatch environment. See https://dysh.readthedocs.io/en/cat-devel/for_developers/doc_standards.html for the new docs instructions.