### PR TITLE
Fix invalid escape sequences in docstrings

### DIFF
--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -10,7 +10,7 @@ class SpectrumPlot:
     """
     The SpectrumPlot class is for simple plotting of a ~spectrum.Spectrum
     using matplotlib functions.   Plots attributes are modified using keywords
-    (\*\*kwargs) described below SpectrumPlot will attempt to make smart default
+    (\\*\\*kwargs) described below SpectrumPlot will attempt to make smart default
     choices for the plot if no additional keywords are given.
     The attributes are "sticky" meaning that an attribute set via
     instantiation or by the `plot()` method will stay set until changed
@@ -20,7 +20,7 @@ class SpectrumPlot:
     ----------
     spectrum : `~spectra.spectrum.Spectrum`
         The spectrum to plot
-    \**kwargs : dict
+    \\**kwargs : dict
         Plot attribute keyword arguments, see below.
 
     Other Parameters
@@ -93,7 +93,7 @@ class SpectrumPlot:
 
         Parameters
         ----------
-        \**kwargs : various
+        \\**kwargs : various
             keyword=value arguments (need to describe these in a central place)
         """
         # xtype = 'velocity, 'frequency', 'wavelength'
@@ -174,7 +174,7 @@ class SpectrumPlot:
             x-axis label
         ylabel : str
             x-axis label
-        \*\*kwargs : various
+        \\*\\*kwargs : various
             other keyword=value arguments
         """
         if title is not None:

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -1,5 +1,4 @@
 """Plot a spectrum using matplotlib"""
-import copy
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -7,10 +6,10 @@ import numpy as np
 
 
 class SpectrumPlot:
-    """
+    r"""
     The SpectrumPlot class is for simple plotting of a ~spectrum.Spectrum
     using matplotlib functions.   Plots attributes are modified using keywords
-    (\\*\\*kwargs) described below SpectrumPlot will attempt to make smart default
+    (**kwargs) described below SpectrumPlot will attempt to make smart default
     choices for the plot if no additional keywords are given.
     The attributes are "sticky" meaning that an attribute set via
     instantiation or by the `plot()` method will stay set until changed
@@ -20,7 +19,7 @@ class SpectrumPlot:
     ----------
     spectrum : `~spectra.spectrum.Spectrum`
         The spectrum to plot
-    \\**kwargs : dict
+    **kwargs : dict
         Plot attribute keyword arguments, see below.
 
     Other Parameters
@@ -88,12 +87,12 @@ class SpectrumPlot:
         return self._spectrum
 
     def plot(self, **kwargs):
-        """
+        r"""
         Plot the spectrum.
 
         Parameters
         ----------
-        \\**kwargs : various
+        **kwargs : various
             keyword=value arguments (need to describe these in a central place)
         """
         # xtype = 'velocity, 'frequency', 'wavelength'
@@ -164,7 +163,7 @@ class SpectrumPlot:
         }
 
     def _set_labels(self, title=None, xlabel=None, ylabel=None, **kwargs):
-        """Set x and y labels according to spectral units
+        r"""Set x and y labels according to spectral units
 
         Parameters
         ----------
@@ -174,7 +173,7 @@ class SpectrumPlot:
             x-axis label
         ylabel : str
             x-axis label
-        \\*\\*kwargs : various
+        **kwargs : various
             other keyword=value arguments
         """
         if title is not None:

--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -159,7 +159,7 @@ class ScanBlock(UserList, ScanMixin):
         weights: str
             'tsys' or None.  If 'tsys' the weight will be calculated as:
 
-             :math:`w = t_{exp} \times \delta\nu/T_{sys}^2`
+             :math:`w = t_{exp} \times \\delta\nu/T_{sys}^2`
 
             Default: 'tsys'
         Returns
@@ -179,7 +179,7 @@ class ScanBlock(UserList, ScanMixin):
         weights: str
             'tsys' or None.  If 'tsys' the weight will be calculated as:
 
-             :math:`w = t_{exp} \times \delta\nu/T_{sys}^2`
+             :math:`w = t_{exp} \times \\delta\nu/T_{sys}^2`
 
             Default: 'tsys'
         Returns
@@ -711,7 +711,7 @@ class SubBeamNodScan(ScanMixin):  # SBNodScan?
         Weighting scheme to use when averaging the signal and reference scans
         'tsys' or None.  If 'tsys' the weight will be calculated as:
 
-         :math:`w = t_{exp} \times \delta\nu/T_{sys}^2`
+         :math:`w = t_{exp} \times \\delta\nu/T_{sys}^2`
 
         Default: 'tsys'
     """

--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -152,14 +152,14 @@ class ScanBlock(UserList, ScanMixin):
         return self._timeaveraged
 
     def polaverage(self, weights="tsys"):
-        """Average all polarizations in all scans in this ScanBlock
+        r"""Average all polarizations in all scans in this ScanBlock
 
         Parameters
         ----------
         weights: str
             'tsys' or None.  If 'tsys' the weight will be calculated as:
 
-             :math:`w = t_{exp} \times \\delta\nu/T_{sys}^2`
+             :math:`w = t_{exp} \times \delta\nu/T_{sys}^2`
 
             Default: 'tsys'
         Returns
@@ -172,14 +172,14 @@ class ScanBlock(UserList, ScanMixin):
         return self._polaveraged
 
     def finalspectrum(self, weights="tsys"):
-        """Average all times and polarizations in all scans this ScanBlock
+        r"""Average all times and polarizations in all scans this ScanBlock
 
         Parameters
         ----------
         weights: str
             'tsys' or None.  If 'tsys' the weight will be calculated as:
 
-             :math:`w = t_{exp} \times \\delta\nu/T_{sys}^2`
+             :math:`w = t_{exp} \times \delta\nu/T_{sys}^2`
 
             Default: 'tsys'
         Returns
@@ -362,7 +362,7 @@ class TPScan(ScanMixin):
         meta["TSYS"] = self._tsys[i]
         meta["EXPOSURE"] = self.exposure[i]
         naxis1 = len(self._data[i])
-        ctype1 = meta["CTYPE1"]
+        meta["CTYPE1"]
         ctype2 = meta["CTYPE2"]
         ctype3 = meta["CTYPE3"]
         crval1 = meta["CRVAL1"]
@@ -536,7 +536,7 @@ class PSScan(ScanMixin):
         meta["TSYS"] = self._tsys[i]
         meta["EXPOSURE"] = self._exposure[i]
         naxis1 = len(self._calibrated[i])
-        ctype1 = meta["CTYPE1"]
+        meta["CTYPE1"]
         ctype2 = meta["CTYPE2"]
         ctype3 = meta["CTYPE3"]
         crval1 = meta["CRVAL1"]
@@ -694,7 +694,7 @@ class PSScan(ScanMixin):
 
 
 class SubBeamNodScan(ScanMixin):  # SBNodScan?
-    """
+    r"""
     Parameters
     ----------
     sigtp:  list of ~spectra.scan.TPScan
@@ -711,7 +711,7 @@ class SubBeamNodScan(ScanMixin):  # SBNodScan?
         Weighting scheme to use when averaging the signal and reference scans
         'tsys' or None.  If 'tsys' the weight will be calculated as:
 
-         :math:`w = t_{exp} \times \\delta\nu/T_{sys}^2`
+         :math:`w = t_{exp} \times \delta\nu/T_{sys}^2`
 
         Default: 'tsys'
     """
@@ -758,8 +758,6 @@ class SubBeamNodScan(ScanMixin):  # SBNodScan?
                 self._calibrated[i] = ta
 
         elif self._method == "scan":
-            tpon = self._sigtp
-            tpoff = self._reftp
             # Process the whole scan as a single block.
             # This is less accurate, but might be needed if
             # the scan was aborted and there are not enough
@@ -784,7 +782,7 @@ class SubBeamNodScan(ScanMixin):  # SBNodScan?
         meta = deepcopy(self._sigtp[i].timeaverage().meta)
         meta["TSYS"] = self._tsys[i]
         naxis1 = len(self._calibrated[i])
-        ctype1 = meta["CTYPE1"]
+        meta["CTYPE1"]
         ctype2 = meta["CTYPE2"]
         ctype3 = meta["CTYPE3"]
         crval1 = meta["CRVAL1"]
@@ -883,8 +881,8 @@ class SubBeamNodScan(ScanMixin):  # SBNodScan?
                 ta_avg[:] += data[i] * self.tsys[i] ** -2.0
             wt1 = self.tsys**-2.0
             wt2 = tsys_weight(self.exposure, self.delta_freq, self.tsys)
-            tavg2 = average(data, 0, wt1)
-            tsysavg2 = average(self.tsys, 0, wt2)
+            average(data, 0, wt1)
+            average(self.tsys, 0, wt2)
             ta_avg /= wt_avg
             tsys_avg /= tsys_wt
             self._timeaveraged._data = ta_avg


### PR DESCRIPTION
These were resulting in SyntaxWarning in Python 3.12:

```plain
dysh/src/dysh/plot/specplot.py:10: SyntaxWarning: invalid escape sequence '\*'
  """
dysh/src/dysh/plot/specplot.py:91: SyntaxWarning: invalid escape sequence '\*'
  """
dysh/src/dysh/plot/specplot.py:167: SyntaxWarning: invalid escape sequence '\*'
  """Set x and y labels according to spectral units
dysh/src/dysh/spectra/scan.py:155: SyntaxWarning: invalid escape sequence '\d'
  """Average all polarizations in all scans in this ScanBlock
dysh/src/dysh/spectra/scan.py:175: SyntaxWarning: invalid escape sequence '\d'
  """Average all times and polarizations in all scans this ScanBlock
dysh/src/dysh/spectra/scan.py:697: SyntaxWarning: invalid escape sequence '\d'
  """
```