### PR TITLE
Drop support for Python 3.8; add support for Python 3.12

### DIFF
--- a/.github/workflows/hatch-and-pytest.yml
+++ b/.github/workflows/hatch-and-pytest.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
@@ -80,7 +81,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/dy
 
 # Run tests across all supported version of Python
 [[tool.hatch.envs.test.matrix]]
-python = ["38", "39", "310", "311"]
+python = ["39", "310", "311", "312"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/src", "/tests", "/bin"]


### PR DESCRIPTION
A few minor tweaks to synchronize test matrix with supported Python versions. Python 3.8 is fully dropped, Python 3.12 is added

Note that these places need to change:
1. `pyproject.toml`:
    - `[project.requires-python]`: Tells pip which versions of Python are allowed to install dysh
    - `[tool.hatch.envs.test.matrix]`: Tells hatch which versions to use in its test matrix (for local tests only, at least currently)
    - `[project.classifiers]`: Inform PyPI about trove classifiers (for search/metadata purposes)
2. `.github/workflows/{hatch-and-pytest,pyinstaller}.yaml:jobs.build.strategy.matrix.python-version`: Add to GH Actions build matrix 