### PR TITLE
Add some printouts to debug platform-dependent precision

### DIFF
--- a/src/dysh/spectra/tests/test_scan.py
+++ b/src/dysh/spectra/tests/test_scan.py
@@ -1,10 +1,7 @@
-import pathlib
-
 import numpy as np
 import pytest
 from astropy.io import fits
 
-import dysh
 from dysh.fits import gbtfitsload
 
 
@@ -121,10 +118,14 @@ class TestPSScan:
         # The system temperature is different because of the squared averaging.
         assert abs(ps_sb[0].calibrated(0).meta["TSYS"] - ta1[0].meta["TSYS"]) < 5e-16
         assert (ps_sb[0].calibrated(0).meta["EXPOSURE"] - ta1[0].meta["EXPOSURE"]) == 0.0
+
+        arr = abs(ps_sb[0].calibrated(0).flux.value - ta1[0].flux.value) < 5e-16
+        print(f"test_blank_integrations: type of arr: {arr.dtype}")
+        print(f"test_blank_integrations: arr: {arr}")
         # Check if the time averaged data matches that from the first integration.
         # assert np.all(abs(ps_sb[0].calibrated(0).flux.value - ta1[0].flux.value) < 2e-19)
         # Set to 5E-16 because Windows OS tests fail below that.  Need to understand why.
-        assert np.all(abs(ps_sb[0].calibrated(0).flux.value - ta1[0].flux.value) < 5e-16)
+        assert np.all(arr)
 
 
 class TestSubBeamNod:


### PR DESCRIPTION
This is just to trigger a build on Windows, since I don't currently have access to a Windows host to test