### PR TITLE
Make ipython a core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,13 @@ dependencies = [
   "scipy",
   "specutils",
   "sphinx",
-  "myst-parser"
+  "myst-parser",
+  "ipython"
  ]
 
 [project.optional-dependencies]
 dev = [
   "ipdb",
-  "ipython",
   "pytest",
   "pytest-cov",
   "wget",


### PR DESCRIPTION
`$ dysh` (`dysh.shell`) requires `ipython`, so it needs to be migrated from an optional to a "core" dependency