### PR TITLE
wget is core dependency because our notebooks used it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "specutils",
   "sphinx",
   "myst-parser",
-  "ipython"
+  "ipython",
+  "wget"
  ]
 
 [project.optional-dependencies]
@@ -39,7 +40,6 @@ dev = [
   "ipdb",
   "pytest",
   "pytest-cov",
-  "wget",
   "myst-parser",
   "sphinx",
   "sphinx-autobuild",


### PR DESCRIPTION
In trying to run notebooks from a clean install, I ran into wget module not found,  so we need to move it to core. 

