### PR TITLE
Patches for `gettp`

### DIFF
--- a/docs/source/examples/positionswitch.rst
+++ b/docs/source/examples/positionswitch.rst
@@ -145,7 +145,7 @@ The system temperature array (`numpy.ndarray`) is stored in `tsys`
 
 .. code:: python
 
-    >>> print(f"T_sys = {pscan.tsys.mean():.2f} K")
+    >>> print(f"T_sys = {psscan[0].tsys.mean():.2f} K")
         T_sys = 17.17 K
 
 Then time average the data, using system temperature weighting (other option is 'equal' weighting; 'tsys' is the default if no `weights` parameter is given. Future upgrade will allow the user to provide a numeric weights array). The returned object is :class:`~dysh.spectra.spectrum.Spectrum`, which has a default `matplotlib`-based plotter attached
@@ -153,7 +153,7 @@ Then time average the data, using system temperature weighting (other option is 
 .. code:: python
 
     >>> ta = psscan.timeaverage(weights='tsys')
-    >>> ta.plot()
+    >>> ta[0].plot()
 
 .. figure:: img/ps_152.png
     :alt: A frequency versus temperature spectrum plot. The spectrum is noisy and spans 1.390 to 1.415 GHz.
@@ -162,7 +162,7 @@ The :meth:`~dysh.spectra.spectrum.Spectrum.plot` command allows changing of axis
 
 .. code:: python
 
-    >>> ta.plot(xaxis_unit="km/s",yaxis_unit="mK",ymin=-100,ymax=500,xmin=3000,xmax=4500)
+    >>> ta[0].plot(xaxis_unit="km/s",yaxis_unit="mK",ymin=-100,ymax=500,xmin=3000,xmax=4500)
 
 .. figure:: img/ps_152_zoom.png
     :alt: The spectrum plot zoomed in along both axes to frame a central emission line.
@@ -181,7 +181,7 @@ is also .  The baseline is removed if `remove=True`.
 .. code:: python
 
     >>> kms = u.km/u.s
-    >>> ta.baseline(order=2,exclude=[3600,4100]*kms, remove=True)
+    >>> ta.baseline(degree=2, exclude=[3600,4100]*kms, remove=True)
     EXCLUDING [Spectral Region, 1 sub-regions:
       (1401242184.363393 Hz, 1403551474.1090915 Hz)
     ]

--- a/docs/source/examples/subbeamnod.rst
+++ b/docs/source/examples/subbeamnod.rst
@@ -39,7 +39,7 @@ The returned `sdfits` can be probed for information
 .. code:: python
 
     >>> sdfits.info()
-    Filename: /data/gbt/examples/subbeamnod-Ka/data/TRCO_230413_Ka.raw.vegas/TRCO_230413_Ka.raw.vegas.A.fits
+    Filename: TRCO_230413_Ka.raw.vegas.A.fits
     No.    Name      Ver    Type      Cards   Dimensions   Format
       0  PRIMARY       1 PrimaryHDU      12   ()
       1  SINGLE DISH    1 BinTableHDU    245   5280R x 74C   ['32A', '1D', '22A', '1D', '1D', '1D', '1024E', '16A', '6A', '8A', '1D', '1D', '1D', '4A', '1D', '4A', '1D', '1I', '32A', '32A', '1J', '32A', '16A', '1E', '8A', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '8A', '1D', '1D', '12A', '1I', '1I', '1D', '1D', '1I', '1A', '1I', '1I', '16A', '16A', '1J', '1J', '22A', '1D', '1D', '1I', '1A', '1D', '1E', '1D', '1D', '1D', '1D', '1D', '1A', '1A', '8A', '1E', '1E', '16A', '1I', '1I', '1I']
@@ -48,7 +48,7 @@ You can also print a concise (or verbose if you choose `verbose=True`) :meth:`~d
 
 .. code:: python
 
-    >>> sdfits.summary()
+    >>> sdfits.summary(show_index=True)
         SCAN     OBJECT VELOCITY        PROC  PROCSEQN RESTFREQ DOPFREQ # IF # POL # INT # FEED     AZIMUTH   ELEVATIO
     0     32  1256-0547      0.0         Nod         1     26.5    26.5    1     2    60      2  160.975324  43.884984
     1     33  1256-0547      0.0         Nod         2     26.5    26.5    1     2    60      2  161.174093  43.928449
@@ -74,4 +74,4 @@ The SubBeamNod scans are 43, 46, and 54.  Retrieve and calibrate a SubBeamNod sc
 .. code:: python
 
     >>> sbn = sdfits.subbeamnod(scan=43, fdnum=1, ifnum=0, weights='tsys')
-    >>> sbn.plot()
+    >>> sbn[0].plot()

--- a/docs/source/examples/totalpower.rst
+++ b/docs/source/examples/totalpower.rst
@@ -36,7 +36,7 @@ You can also print a concise (or verbose if you choose `verbose=True`) summary :
 
 .. code:: python
 
-    >>> sdfits.summary()
+    >>> sdfits.summary(show_index=True)
         SCAN   OBJECT VELOCITY   PROC PROCSEQN  RESTFREQ   DOPFREQ # IF # POL # INT # FEED     AZIMUTH   ELEVATIO
     0  152.0  NGC2415   3784.0  OnOff      1.0  1.617185  1.420406    5     2   151      1  286.218008   41.62843
     1  153.0  NGC2415   3784.0  OnOff      2.0  1.617185  1.420406    5     2   151      1  286.886521  41.118134
@@ -46,13 +46,12 @@ Retrieve a scan, selecting and IF number and polarization
 .. code:: python
 
     >>> tpscan = sdfits.gettp(152, ifnum=0, plnum=0)
-        TPSCAN nrows = 302
 
 The `~dysh.spectra.scan.GBTTPScan` contains the individual integrations.  The system temperatures per integration are calculated from the CALON and CALOFF data
 
 .. code:: python
 
-    >>> print('%s' % (np.array2string(tps.tsys,precision=2)))
+    >>> print('%s' % (np.array2string(tpscan[0].tsys, precision=2)))
         [16.89 16.89 16.94 16.77 16.96 16.94 16.87 16.86 16.92 16.86 16.85 16.97
          16.79 16.86 16.96 17.02 16.94 16.89 16.87 16.92 16.88 16.86 16.92 17.02
          16.77 16.8  17.   16.91 16.91 16.86 16.98 16.81 16.88 17.03 16.96 16.95
@@ -71,7 +70,7 @@ You can time-average the data, in this example with equal weighting per integrat
 
 .. code:: python
 
-    >>> tps.timeaverage(weights=None).plot()
+    >>> tpscan.timeaverage(weights=None)[0].plot()
 
 .. figure:: img/tp_153_eqweight.png
     :alt: A plot of the time-averaged data

--- a/docs/source/getting_started/tutorials/GBT/tutorial-positionswitch.rst
+++ b/docs/source/getting_started/tutorials/GBT/tutorial-positionswitch.rst
@@ -29,6 +29,14 @@ You can install `dysh` using `pip`. From a terminal type
 
     pip install dysh
 
+
+After installing `dysh` you can start it by typing `dysh` in a shell. Alternatively, you can import it as any other `Python` module.
+
+.. code:: bash
+
+    dysh
+
+
 Downloading the raw data
 ------------------------
 
@@ -61,7 +69,7 @@ Now you will load the raw data and show a summary of its contents
 .. code:: python
 
     >>> sdfits = GBTFITSLoad(filename)
-    >>> sdfits.summary()
+    >>> sdfits.summary(show_index=True)
         SCAN   OBJECT VELOCITY   PROC PROCSEQN  RESTFREQ   DOPFREQ # IF # POL # INT # FEED     AZIMUTH   ELEVATIO
     0    152  NGC2415   3784.0  OnOff        1  1.617185  1.420406    5     2   151      1  286.218008   41.62843
     1    153  NGC2415   3784.0  OnOff        2  1.617185  1.420406    5     2   151      1  286.886521  41.118134
@@ -74,7 +82,6 @@ The following lines will let you calibrate and time average the position switche
 .. code:: python
 
     >>> psscan = sdfits.getps(152, ifnum=0, plnum=0)
-        PSSCAN nrows = 302
     >>> psscan.calibrate()
     >>> ta = psscan.timeaverage(weights='tsys')
 
@@ -83,7 +90,7 @@ Plotting the calibrated data
 
 .. code:: python
 
-    >>> ta.plot(xaxis_unit="km/s",yaxis_unit="mK",ymin=-100,ymax=500,xmin=3000,xmax=4500)
+    >>> ta[0].plot(xaxis_unit="km/s",yaxis_unit="mK",ymin=-100,ymax=500,xmin=3000,xmax=4500)
 
 .. figure:: img/ps_152_zoom.png
     :alt: The spectrum plot zoomed in along both axes to frame a central emission line.

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -310,8 +310,10 @@ class GBTFITSLoad(SDFITSLoad):
             compressed_df = pd.concat([compressed_df, ser.to_frame().T], ignore_index=True)
         compressed_df = compressed_df.astype(col_dtypes)
         if not show_index:
-            return compressed_df.style.hide(axis="index")
-        return compressed_df
+            print(compressed_df.to_string(index=False))
+            # return compressed_df.style.hide(axis="index")
+        else:
+            return compressed_df
 
     def velocity_convention(self, veldef, velframe):
         # GBT uses VELDEF and VELFRAME incorrectly.

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -177,7 +177,7 @@ class GBTFITSLoad(SDFITSLoad):
         """
         return self._sdf[fitsindex].rawspectrum(i, bintable)
 
-    def summary(self, scans=None, verbose=False, show_index=False):  # selected=False
+    def summary(self, scans=None, verbose=False, show_index=True):  # selected=False
         # From GBTIDL:
         # Intended to work with un-calibrated GBT data and is
         # likely to give confusing results for other data.  For other data,

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -504,7 +504,8 @@ class GBTFITSLoad(SDFITSLoad):
                 print("TPROWS len=", len(tprows))
                 print("CALROWS on len=", len(calrows["ON"]))
                 print("fitsindex=", i)
-
+            if len(tprows) == 0:
+                continue
             g = TPScan(
                 self._sdf[i], scan, sigstate[sig], calstate[cal], tprows, calrows, bintable, kwargs_opts["calibrate"]
             )


### PR DESCRIPTION
This patch fixes Issue #132.
Now `gettp` will skip the creation of a `TPScan` if the input selection results in zero rows.