### PR TITLE
97 test example notebooks ps

### DIFF
--- a/notebooks/examples/positionswitch-test.ipynb
+++ b/notebooks/examples/positionswitch-test.ipynb
@@ -1,0 +1,390 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8c8138ef-e687-444e-95b1-9797654f3f62",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Position-switched Data Reduction\n",
+    "----------------------------------\n",
+    "\n",
+    "This notebook shows how to use `dysh` to calibrate an OnOff observation.\n",
+    "It retrieves and calibrates position-switch scans using `GBTFITSLoad.getps()`, which returns a `ScanBlock` object.  OffOn observations can be reduced the same way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b4967550-2ca1-4931-b53b-6f9868718490",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "import"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import wget\n",
+    "import astropy.units as u\n",
+    "from dysh.fits.gbtfitsload import GBTFITSLoad"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87669763-8d96-4521-9e81-f69d7213e133",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## First, we download the example SDFITS data, if necessary.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6bc88bc5-986d-4eae-b1c7-6398cc9ddd5a",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "wget"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TGBT21A_501_11.raw.vegas.fits already downloaded\n"
+     ]
+    }
+   ],
+   "source": [
+    "filename = \"TGBT21A_501_11.raw.vegas.fits\"\n",
+    "if not os.path.isfile(filename):\n",
+    "    url = f\"http://www.gb.nrao.edu/dysh/example_data/onoff-L/data/{filename}\"\n",
+    "    print(f\"Downloading {filename}\")\n",
+    "    wget.download(url,out=filename)\n",
+    "    print(f\"\\nRetrieved {filename}\")\n",
+    "else:\n",
+    "    print(f\"{filename} already downloaded\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "93a62e3a-c95d-475b-8602-b5b8b7934733",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "load"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filename: TGBT21A_501_11.raw.vegas.fits\n",
+      "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY       1 PrimaryHDU      12   ()      \n",
+      "  1  SINGLE DISH    1 BinTableHDU    245   6040R x 74C   ['32A', '1D', '22A', '1D', '1D', '1D', '32768E', '16A', '6A', '8A', '1D', '1D', '1D', '4A', '1D', '4A', '1D', '1I', '32A', '32A', '1J', '32A', '16A', '1E', '8A', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '1D', '8A', '1D', '1D', '12A', '1I', '1I', '1D', '1D', '1I', '1A', '1I', '1I', '16A', '16A', '1J', '1J', '22A', '1D', '1D', '1I', '1A', '1D', '1E', '1D', '1D', '1D', '1D', '1D', '1A', '1A', '8A', '1E', '1E', '16A', '1I', '1I', '1I']   \n"
+     ]
+    }
+   ],
+   "source": [
+    "sdfits = GBTFITSLoad(filename)\n",
+    "sdfits.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1d71d0c8-6ff4-4c89-a76e-df2648ee41b6",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SCAN</th>\n",
+       "      <th>OBJECT</th>\n",
+       "      <th>VELOCITY</th>\n",
+       "      <th>PROC</th>\n",
+       "      <th>PROCSEQN</th>\n",
+       "      <th>RESTFREQ</th>\n",
+       "      <th>DOPFREQ</th>\n",
+       "      <th># IF</th>\n",
+       "      <th># POL</th>\n",
+       "      <th># INT</th>\n",
+       "      <th># FEED</th>\n",
+       "      <th>AZIMUTH</th>\n",
+       "      <th>ELEVATIO</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>152</td>\n",
+       "      <td>NGC2415</td>\n",
+       "      <td>3784.0</td>\n",
+       "      <td>OnOff</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.617185</td>\n",
+       "      <td>1.420406</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2</td>\n",
+       "      <td>151</td>\n",
+       "      <td>1</td>\n",
+       "      <td>286.218008</td>\n",
+       "      <td>41.62843</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>153</td>\n",
+       "      <td>NGC2415</td>\n",
+       "      <td>3784.0</td>\n",
+       "      <td>OnOff</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.617185</td>\n",
+       "      <td>1.420406</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2</td>\n",
+       "      <td>151</td>\n",
+       "      <td>1</td>\n",
+       "      <td>286.886521</td>\n",
+       "      <td>41.118134</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   SCAN   OBJECT VELOCITY   PROC  PROCSEQN  RESTFREQ   DOPFREQ # IF # POL  \\\n",
+       "0   152  NGC2415   3784.0  OnOff         1  1.617185  1.420406    5     2   \n",
+       "1   153  NGC2415   3784.0  OnOff         2  1.617185  1.420406    5     2   \n",
+       "\n",
+       "  # INT # FEED     AZIMUTH   ELEVATIO  \n",
+       "0   151      1  286.218008   41.62843  \n",
+       "1   151      1  286.886521  41.118134  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sdfits.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "684126da-97d4-4afb-8625-43160340cab1",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "getps",
+     "test"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "psscan = sdfits.getps(152, ifnum=0, plnum=0)\n",
+    "psscan.calibrate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5deaae0c-e70b-4758-ae10-f11c6f66cc3b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "print_tsys",
+     "test"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "T_sys = 17.17\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"T_sys = {psscan[0].tsys.mean():.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e0a33c19-576b-46e8-9a57-f34b8f85f6aa",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "timeaverage",
+     "test"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: NoVelocityWarning: No velocity defined on frame, assuming (0., 0., 0.) km / s. [astropy.coordinates.spectral_coordinate]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ta = psscan.timeaverage(weights='tsys')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "40747f0b-d63d-45fa-8910-fef56fe5c751",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "plot1",
+     "test"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj8AAAGxCAYAAACN/tcCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABHr0lEQVR4nO3dd3hUZf7+8XsIyaSRQEggBEILvQeQrgRBiqxiXcUCrIrlC6uCBdgVAVtYbKCyWH+Iriiigq4KCEhRpEOklwRCAoHQkxBInfP7I8uQIYUkZDIZzvt1XXNdOWXOfM4zkzn3PKdZDMMwBAAAYBJVXF0AAABARSL8AAAAUyH8AAAAUyH8AAAAUyH8AAAAUyH8AAAAUyH8AAAAUyH8AAAAU6nq6gIqgs1mU1JSkqpVqyaLxeLqcgAAQAkYhqG0tDSFhYWpSpXy668xRfhJSkpSeHi4q8sAAABlkJiYqHr16pXb8kwRfqpVqyYpr/ECAgIcpqWmpio8PLzQaXA+2t+1aH/X4z1wLdrfta7U/henX9yOlxdThJ+Lu7oCAgKK/HAXNw3OR/u7Fu3verwHrkX7u9aV2r+8D1nhgGcAAGAqhB8AAGAqpg8/VqtVkyZNktVqdXUppkT7uxbt73q8B65F+7uWq9rfYhiGUaGv6AKpqakKDAxUSkoK+3QBAHATztp+m77nBwAAmAvhBwAAmArhBwAAmArhBwAAmArhBwAAmArhBwAAmArhBwAAmArhBwAAmArhB5Kkt5bu05CZa7T9cIqrSwEAwKkIP1Di6fN6Z/l+/Zl4Vne+/4erywEAwKkIP9DJc5n2v7NybC6sBAAA5yP8AAAAU3Hb8DNr1iy1a9dOAQEBCggIUPfu3bVo0SJXlwUAACo5tw0/9erV09SpU7V582Zt2rRJN954o4YMGaKdO3e6ujQAAFCJVXV1AWV1yy23OAy/+uqrmjVrltatW6fWrVu7qCoAAFDZuW34yS83N1fz589Xenq6unfvXuR8qampDsNWq1VWq9XZ5QEAgBLIzMxUZualk3Au326XF7fd7SVJ27dvl7+/v6xWqx5//HEtWLBArVq1KnL+8PBwBQYG2h/R0dEVWC0AAChOdHS0w3Y6PDzcKa9jMQzDcMqSK0BWVpYSEhKUkpKib775Rh9//LFWrVpVIAClpqYqMDBQiYmJCggIsI+n5yfP1oQzuv3fl67vEz91sAurAQCYVWE9P+Hh4UpJSXHYfl8tt97t5eXlpSZNmkiSOnXqpI0bN2rGjBn64IMPCp3/4plhAACg8qmoTgm33u11OZvN5pAYAQAALue2PT8TJkzQoEGDVL9+faWlpWnu3LlauXKllixZ4urSAABAJea24ef48eMaNmyYjh49qsDAQLVr105LlizRTTfd5OrSAABAJea24eeTTz5xdQkAAMANXVPH/AAAAFwJ4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QeyWCyuLgEAgApD+AEAAKZC+AEAAKZC+AEAAKbituEnOjpa1113napVq6ZatWrptttu0969e11dFgAAqOTcNvysWrVKo0aN0rp167R06VJlZ2erf//+Sk9Pd3VpAACgEqvq6gLKavHixQ7Dn376qWrVqqXNmzfrhhtucFFVAACgsnPb8HO5lJQUSVJQUFCR86SmpjoMW61WWa1Wp9YFAABKJjMzU5mZmfbhy7fb5cVtd3vlZ7PZ9PTTT6tnz55q06ZNkfOFh4crMDDQ/oiOjq7AKgEAQHGio6MdttPh4eFOeZ1roudn1KhR2rFjh37//fdi50tMTFRAQIB9mF4fAAAqjwkTJmjs2LH24dTUVKcEILcPP6NHj9aPP/6o1atXq169esXOGxAQ4BB+AABA5VFRh6O4bfgxDEN///vftWDBAq1cuVKNGjVydUkAAMANuG34GTVqlObOnavvv/9e1apV07FjxyRJgYGB8vHxcXF1AACgsnLbA55nzZqllJQURUVFqU6dOvbHvHnzXF0aAACoxNy258cwDFeXAAAA3JDb9vwAAACUBeEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHAACYCuEHMgzD1SUAAFBhCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD8AAMBUCD+QxWJxdQkAAFQYwg8AADAVwg8AADAVwg8AADAVwg8AADAVwg8AADAVtw0/q1ev1i233KKwsDBZLBYtXLjQ1SUBAAA34LbhJz09Xe3bt9fMmTNdXQoAAHAjVV1dQFkNGjRIgwYNcnUZAADAzbhtzw8AAEBZuG3PT1mkpqY6DFutVlmtVhdVAwAA8svMzFRmZqZ9+PLtdnkxVc9PeHi4AgMD7Y/o6GhXlwQAAP4nOjraYTsdHh7ulNcxVc9PYmKiAgIC7MP0+gAAUHlMmDBBY8eOtQ+npqY6JQCZKvwEBAQ4hB8AAFB5VNThKG4bfs6dO6fY2Fj78MGDBxUTE6OgoCDVr1/fhZUBAC53IStXPl4eri4DkOTGx/xs2rRJkZGRioyMlCSNHTtWkZGRevHFF11cGQAgv/HfblPbyUv0xfpDri4FkOTGPT9RUVEyDMPVZQAAimEYhr7amChJ+ueCHbq/awMXVwS4cc8PAABAWRB+AACAqRB+AACAqRB+AACAqRB+AACAqRB+AACAqRB+AACAqRB+AACAqRB+AACAqRB+AKASupCVq2mL9+jj3w5wNXugnLnt7S0A4Fr27q/79e+VcZKkxiF+urFFbRdXBFw76PkBgEro0z/i7X8v3ZXsukKAaxDhBwAqOfZ6oSIcOHFOv+5JVq7t2v/AEX4AE/v4twN6/PPNSjh13tWl4DIWVxcAU0m5kK2+b63SQ59u0hfrD7m6HKcj/AAmFXv8nF75abcW7zymx/6z2dXloBj0/MDZFm0/av+cvfj9TtcWUwEIP4BJHThxzv737qOpLqwEhbFY6PtxtviT6Xrx+x36ff9JV5ficmbL14QfwKTM9mXnzgzeLae476N1+mztIT3wyXpTHOdSHLP1LhJ+AJMy25edu6Hfx/mSUjLsf2fn2lxYieuZLWATfgCgkiOoAuWL8AOYVMLpdFeXUK7SM3P047YknTyX6epSyke+rh+yD5zNbAGbKzwDJpVyIdvVJZTZR6sP6MsNCarp76UqFov+ObilPlh9QD9tO6pmtf31y5jeysqx6VhKhurX9HV1uabmLhtVd6nTWcy2+oSfSspmM3T2QraC/LxcXYppHEvJUO0AK2fZuFhmTq6Op2YqPKjo0PLqz7slSQdO5vVe3freGvu0fcnnZBiGbv/3Gu1MStVrt7fVfV3rO7doJ8j/KTT7hrkinDyXqTd/2asGNf005qZmri6n4pnsQ8Zurwp2Oj1L93+8To9/vrnIA+wMw9DdH6zVda8u0w9/JpX5tXYfTVXi6aIvXmcYRrncMNFWTmdJZOXYlJGdWy7LKq3py/apW/RyPT0vxiWv7woWJx5SuzMpRbNWxulEWul2Qdlshga/87uun7ZCC7YeLvPrv7Bwh3Ym5Z2+/48F20v0nBNpmRr64TqN+mKLcvL9b1b0TUXPpGeV2/8USu6fC3doYUySZizfr9/2n3B1OXAywk8Fm/zDTq2JPaXFO4/p0zXxhc6zMylVmw+dUa7N0JNfbi3T66w/cEqDZvymqDdWFnoNl/NZObr1vTW68c1VOnr2QomXe/mG4MPVcWr/0i/6dM1BSWU/Y+LUuUz1/Nev6ha9vNjA5izTl+2XJH0fU/awmV/S2QuatzFBZ9KzSvW8jOxcHct3BkppGIahPxPP6lxmTqHTU85nO7x/5X12x9nzWfpm82F9/NsBDX7nd/1r8R79/cstkvKC7eOfb9YDH68vtk02xp9W7PG86w+NmfdnofOUJCB/sT7BYfjI/96Pp77aWuTVrF9YuF1rD5zST9uPau6GvOcv3ZWsTq8s06TvdxRax8wVsfpyQ0KBaRfl2gydzyr8/SjMD38mqfOry/TXD9Y69EB+u+Vwgf+tn7Yd1c0zftN3W8oeEksqMydXi3ccLfJ/83hqhj5afUCxx9Mk5a13Zo5rfsiU1ep9lwLP1oSzriukAhmGof3JacrOtenEudJ9V7k7wk8F+yPu0sW0Fmw9ouxcm77elKjJP+zU2rhTkqTMnJIFiLgT5/TVhgSlZWTr4Ml0hy+mUXPzQlOuzdCgGb/p1Z92OTx35opYbT+SooMn0/XEF1sca4w9qaMpBQPR+gOn1D36Vz3z9aWN0ms/71FaRo4m/3eXRszeoI4vLS3xBcO2H07RfR+t0+w1BzVt8V6dSMvU2fPZGv/dNof5dh9N1XPz/9RDn27U5B92FnmsyoET53T/x+v0+pI99nFFBYErOZ6WoSn/3Vlkz1vi6fNasvOYsvK9V+sPnNL9H6/T9zFHdNesPzTu2+168qutysm1OYYOw9C/V8bqX4v3OGzIUzOy1WLiYnWLXq6HP92otIxL6xmTeFZ/xOW9L5/8frDQjdCkH3ZqyMw1ajNpiQ6fcZz+fcwRdXxlqe77aL0Mw9APfyZp5oo4h3ke/3yzNsafLl1D5fPo55v17Pw/9cpPu+3j1h3IW97/W3NQi3ce0++xJx16YvYeS1O315brwU/Wa++xtBJda+Wmt1eVuraeU3/VuG+36/uYJN3w+grtOZaqfy7YrpkrYu3z/Jbvc3vxB8PIzzbpdHqW5qw9pONpjqH0k98P6vUlezXhu+0OG86LMrJz1ffNlery6nJtP5xSaF3ns3KUmu99fvLLrcq1Gdp06EyBz/kT/9milAvZeuuXvfp5+1GNmrtFu46mauz//h9TLmTrlR93ac4f8Q6ft6SzF3TXrD9063u/X7FHyTAMPfXVVkW9vkI7jlyq+d3lsXr8P1s0aMZvhYaaRz7bpFd/3q0B03/T+awc9Xtrlbq9tlz7k9OKfb2yyP8/46zT022F9PaVtDcuJ9empFL8oCwvUxft0V/fX1uqNn/v11jd9PZqPfDxer2zfL8Tq6t8LEZF9+m6QGpqqgIDA5WSkqKAgACX1tL5laU6mS9hd6xfXVvy/cqoV8NH/VuF6v/9rydFkib+pZUe7NZAhgxZq3rIZjO0ct9xPfTppgLLX/FslBoF+6nDS7/o7HnHL8/vR/VU+/DqkqSG438qts7qvp5aN6Gvthw6o192JWtEj4aKemOlffrip69XkK+Xury2vNDnx08dLClvI/Lkl1vVtl6gxg1soWreVeXrVbXYGhrW9NXK5/pIkg6dSteNb65y2Cje0zlc/7qrnbJzbdp48LTah1eXn7Wqbnxjpf0YkB9G99S/Fu/RmthT6t+qtibd2lp1q/vYl5Gda9Nv+08o1yb1a1lLjSb8bJ/27RM9NH3ZPvvGsGktf/0wupfOZeboP+sOqW4NHz3/zaWAdjD6ZlksliLXp1Y1q3y8PLTk6RtkrVpFk37Yqc/W5t07p1/LWnpnaKR8vaoq6vUVir+sV+KvneupbnVfvb1sX4HlvndfpAa3rWPvIbj89Vc/18d+sG/+aS1Cq2nPsaK/IJvXrqa9yWka1r2BQvytenPpPjWs6at5j3XXR6sPSJJybIZG9GgoXy8PDZ+9UZH1q2vu+sJ7QP5xcwutiT2lVfkCwnMDmuvztYd0LPVSoAjwrqoPHuysoR+ts4+bPeI6PTRno+pW99G5zJwCn+nycGfHerqjY13d//F6+7h7rwuXp0cVfb7u0j2O6tXw0Ypno5SemaNlu4/r2fmXfgTU8PVUpwZBiqxfXX9pV0cNavpp/Lfb9NXGRElSSDWrPh7WWX8ePqsvNyRqwqAWmr5sn7YknJWvl4d+fvJ6NQz2u+L/5Z0d6+nbQnp6HurZSD9vP+rQnoueul61A7w16ostWnvglH187KuD5FHFop1JqTqWkqE+LWrJo4pFSWcv6Nc9x/XCwrxeruq+noq+va1+jz1ZoCft68e6q0ujIPtw/rrH9Gtm/7y2CK2mn5+8Xo3/cen/6+J3gyRtPnRGi7Yf1Y0taumn7UdlM6Rb2tdRj4hgnUnPUo3Ljnl8f1Wc3liyVyNvaKwavp5685d9eiIqQk/3u3SMTkZ2rrw9PSTlBb+vNyWqb4vaalsvsEC7FdXeT/Ztqod6NpS3p4e8PT0UfzJdD3yyXsH+Vs17rJusVT0KPCfuxDnN+SPe/r/dsk6A7ulcT8O6N1SVKiXfxZwXnoo/UH/DwdNKz8xRVPMQWSwW7UxK0eB3frdPH9UnQgNb17Gv87nMHCWePq/tR1J0S7sw+Xh5FLv+0qXvNVdz1vab8FOBMrJz1WLi4jI9t329QP15OEW1qlk1flAL+6+9wqx6Lkq9X19ZxirLR/zUwXrzl71699dYh/F+Xh56oHsDfbDqQLHPH9olXF9uSCxy+tv3tLfvFuncoIa+eaLHFTccHzzYSV0aBqnH1F91Id+vx/cf6KTHr+LeVgNbh2r6vR3K/N5GhPhp6ZjeDhuIknr7nva6PbKepMK/yKp55wXNtIyy9YBVtHmPdtM9H6678ozXmMbBfnppSBs98Mn6K89czu7oWFe9m4Xoqa9iSvW8XS8N0I4jeT1kf/1grcPyvttyxD584LWbHT7b7eoFKsjPS/d3baCRnxX8AZff329sor92Dtd/1h/SYzdEqOPLSwudL37qYK3Ye1x/m73RPu635/vo+mkr7MMz7u2gN37Zq4gQfw1uW0f9W4Wq/Uu/XHE93xka6XD4wQuDW+qR6xs7zDN/U6Ke+2bb5U+VJL15d3vd2ameVuw5rr99mlffmvE3OvwYk6TFO47p8JnzWrD1iP14tYGtQzXxllZatitZM5bv19v3dFAVi/TgJxsk5YXhBVsPK8jPWuglHuKnDtbbS/dpRr5enYd6NtKLt7RSVo5NzV5YVOR6B/l56am+TTW8R8NiWsf5CD9XwdXh55vNh7Um9qSqWCyF/mq7FlWzVlVaGXc5mVFNPy+dKuXxQflF1q9umuMU4F78rVXLvPu5surbopaOnL2gkGpWTRjUUje/81ux88+8r6NGzXU8vOClIa31zebD2lbELtHyMPeRrrrv46sL1DEv3qTqvq4765jwcxVcGX5OpGXquleXVehrAgBQXu7oWFfjB7ZQrQDvCn9tZ22/OeDZyQ6durauogsAMJfvthzR38t45nFlRfhxop+2HdVd76+98owAAFRi6w+eLtHZmO6C8OMkK/YeL7CPFwAAd3X/x9fOyQiEHyfYl5zmcNYBAADubt2B01q6K9ntLmBZGO7tVU5Op2fp+W/+VI7N0Mq9XBodAHDtuXh5ghXPRmnBlsOKalFLfl5V9ekfBzWwTR31bhbi4gpLhrO9rtKOI3n3MPp1z3GHa8cAAGA2B167uVQXdbwSZ22/6fm5SrfNXKOca+ggMAAAyspdtoYc83OVCD5A5VAJrsQPwE3Q83MVCrv5J4CKM6pPhG5qFSofTw+FBnqr/ZQr364AgPPkHUlT+X+JlDn8ZGdn69ixYzp//rxCQkIUFBR05SddY568xi76BLibQW3qqE3dgjesBOAa7rIvpFS7vdLS0jRr1iz17t1bAQEBatiwoVq2bKmQkBA1aNBAI0eO1MaNFXuK98yZM9WwYUN5e3ura9eu2rBhQ4W99sb4MxX2WgAcvXdfZIHg89yA5i6qBoAk2dzkHKoSh5+33npLDRs21OzZs9WvXz8tXLhQMTEx2rdvn9auXatJkyYpJydH/fv318CBA7V///4rL/QqzZs3T2PHjtWkSZO0ZcsWtW/fXgMGDNDx48ed/town6a1/F1dQqU2flCLCnut/a8O0l/ahRUY/0TvCD3Zt2mF1VGcLg2D9EivRq4uA6hQ7nIV6BKf6j506FC98MILat26dbHzZWRk6NNPP5WXl5ceeuihcimyKF27dtV1112n9957T5Jks9kUHh6uv//97xo/frx9PmedKtdw/E/ltqxJt7TSlP/uKrflFWfGvR301FcxV5zv5SGt1bVxTb34/Q6tO3DaPv7Hv/dSm7qBOnDinMKq++jD1Qf01tJ9ah9eXV0a1tDaA6e040hqscse1r2BPlt7qNh5HuzWQEt3JetYakaR83h5VJHNMLToqetVw89L1/9rhS5k5+rl29rowW4N9K/FezRrZdwV17Uk4qcOVq7NUNLZC9p06LTmbzqsQB9PLdpxrMzL3PRCPwX7WyVJc/6I144jKZq/+bAkyduzijo1qKE1safs82+f3F9tJ186ruXXZ3pr2e5kvfbzHvu4HhE19UC3Bnryy61lPiD/j/E3KsDHU7k2w34cTacGNfTlyG7yqpr3m+nHbUkaPTdv1++nf7tOUc1ryWYztDH+tBqH+KuGr6eSzmbo/605qE//iC/xa788pLVa1gko8tYwK56NUqNgvyKfbxiGVu8/qeH/71Iv8JyHumj9gVPq1TRYtapZ1e+t1fZp7cOr68/EsyWuryT6t6qtD4d1liRtOHhaQz9ap7s71VOtalbNWhWnp/s10+C2dfTUV1v1Z767ev/j5hYO72VRIkL8FHeibPcN3PXSAC3dlXzF74BlY29waKfyUsPXU2fOZzuMe3doZKnuHRUe5KPE0xV7zGU1a1WlVfK701etYinT/3yjYD8dPFk+96HcNrm/Arw9y2VZkhvd1f3cuXPy93f+L+SsrCz5+vrqm2++0W233WYfP3z4cJ09e1bff/+9fdzFxktMTHRoPKvVKqvVWuYayiv89IioqQGtQzXph532cd+P6qkhM9fYh8fe1Eyj+jTRf/9M0tPzYuRvraph3Rvo3yvjZK1aRbe2D9O+5DTd3LaOAn08Nf677fbnhlSz6j8Pd9Wbv+xVzybBGt6jofYeS9OA6avlUcVSIKlvmXiTjqZcUOswx10KuTZDHoVcv8EwDO0+mqaIWn6yVvUotm36taylybe2Vt3qPvo99qR+/POobousq//7YrOycw29e1+k4o6fU7fGNe27NOJOnNOOIykKq+6jqYv2aPOhM/KqWkU/jO6pYH+rbDbDfrdhwzB09ny2avh52V9zzh/x9rZ9rHdjDb2uvqLeWOlQV9Na/vL3rqqtCWcdxu0/fs4+HD91cKHrJEmf/H5QL/94KbzOvK+jmof6q99bq3V7ZF0N7VJf2w6f1b7kNN1zXbiOpmSoX8va8vb0KLCsjfGn9UNMkh7s3kDNalfTqn0ntDn+tO7pUl91q/vol53H9OHqA/rXXe0UEeKv7Fybftp2VNm5NrWtF6gWoZc+4zm5NmXk2ORvrapcm6Flu5P1y85kfbvlsLw9qygj22af9/dxfbRi7wm1CQtQZP0aRa5rfoZhKD0rV/7W4g8fzMm16V+L9+jPwymaekdb3fjmKofpVatY9M7QSHl7VlHvZrXkUcWid5bv11tL90nKC8IPdGugBjV9C22zwpzLzNHCrUfUIby6w+6xzJxcNX9hsSTp9si6evueDvZpCafOK9tmU9989Q1uV0c/bTsqSbqnc7gaBPtq2uK99un/urOtxn2b9/826ZZW8vH00N2dwwv9X5GkrBybPUAu3HpET8+LsU+LnzpYA6ev1p5jaYU+11q1iro0CtKsBzrp+n/9qjPnszWoTaim3NpaU37cpRNpmZp1f0cdT8vU9zFJuqtTXUWE+OueD9dpw8HTmnFvBw3pUFc2m6HfY0/qWGqGArw99fh/Nhd4rfipg7U14Yzmbz6sodfVV9t6eW24+dBp3Tmr7Pcs3PfKIH36x0F7yHtuQHON6tNEQ2auKVEI9fH00O6XB+qv76/VhvjTV5w/v34ta+vte9rrvV9j1aNJsENA/ubx7vps7SH98GeSpt7RVrd3rKs/4k5pa8JZ9WtZS81qV9P7q+I0fVnRezXu61pfc9cnFDpt7ysD7Z87Ke8z/egNjRUe5CtJSsvI1qLtxzRhwXb1a1lLAd6emr/5sF4e0loTv7+0bXh+YHNFhtdQvRo+un7aCvv4i9fXubhJNwzp5x1H9czXfyozx6axNzXTk32b6p8LtuuL/9W45+WByrEZ8rdWLbft2daJNzl8/5ZWZmamMjMz7cOpqakKDw93bfh5++23NWbMmCKnp6WlaeDAgVqzZk2R85SXpKQk1a1bV3/88Ye6d+9uH//8889r1apVWr9+vX3cxfBzuUmTJmny5MllrqG8PiyD29bR33o2tP/S7RFRU3NHdlPCqfNKSrmg81k5ur5piDw98r4wE0+fV6CvpwK8PZWcmqFa1ayyXHae75n0LAX6eGpvcprCqvso0KfoJL54xzGHL7/iNvIltWxXst5bEau/9WyoDuHVNemHnWoU7KdJtxTec5iRnatcmyG/K2xEJclmM0p1Ea3sXJtmrzkoH08PPdCtgSwWi77bcljbDqdoVJ8mCqmWF4BTLmTro9UH9NXGBEU1r6V/3dlOS3Ye00v/3aX7uta/4u6U81k5Wn/wtLo1qikfr5JtoF0l4dR5HUvN0F8/uLQRK4/3vaTy/+/8d3Qv1Q60qlY1b4d5snNtemPJXtkMQ88NaGEPDOVh77E0bTp0Wre2D1O1Qn6l5q8vfupgrd53QruOpur+/23cohdd6p2Je+1mrdhzXHWqexf4wXAlK/ce14h8t8KJnzpYNpuhAyfTNWD66gI/TJaNvUFNalWTJKVn5mjDwdPq1vjKnzfDMJSWmVPkL/ILWbmauyFBmw+d1roDpzW8e0M91a/oz/vLP+7StsNnNfXOvAAee/ycgv29tHLvCQX6euqGpiHafOiMIkL8lJljU4+pvzqso5S3sd+XfE4d61eXxWLR6fQsLdudrKjmIery6nKH13siKkIB3p7aGH9aLwxuqcYh/jIMQ8fTMvXz9rzgL6lAr9m4gS2051iqvo9JkiQ9eWMTje1/6biw/O/zxR7t/OG0MNOX7dP0ZfvVp3mIVuS7mv/1TYP1+cNdC4S4b5/oroY1/VTT36rHPt+kJTuT1b1xTX35aLdCl5+aka1q1qr27/SksxcKbT9Jmrhwh5bsPKbX725f4isrG4ahQ6fOq0FNX4ftxufrDmniwh0Or7Niz3H97dPSHce78Z/97N+pZTF58mRNmTKlwHiXhh8fHx998MEHGjZsWIFp6enp6t+/v06dOqU9e67cbXu1yhJ+XN3z80C3+vpm82GHX9vSpW78Gcv2a29yqib+pZXqBPqUua7Sckb4QeW3Kf60w66linzfl+1K1oerD+ihXo00sE1ohb1uSW04eFr/Xhmrv3YO181t6zhMO3QqXb1fXylJerpfUz3dr1mZX8cwDN330XrtOpqqj4d31nUNL5012/yFRcrMcfyu+GP8jQqr7tzvBsMwCvyYuhpnz2epw0tL7cMl+Zwt352sKf/dpYTT5xUa4K2lY28oNKTml51r0/cxSTqXka13fo1Vs9r++nJkN51Oz9LDczbJx9ND/2/EdQ5BMf93eNxrNxfZW1eU42kZuvv9tfKoYtGCJ3oq0NdTX25I0IR8Pe/51zc9M0e/x55U94iapdo19Pm6Q1obd1LPDWhRYJdveb1fX29K1PPfbCtQd0Z2rlpMXFzU0wpYN6GvQgO9rzxjESqq56dUp7p//vnnevDBB1W9enXdeuut9vHp6ekaMGCATpw4oVWrVhWzhPITHBwsDw8PJScnO4xPTk5WaGjhX6YBAQHlfnuLknhuQHP9X1SELBaLvt18xD6+RWg1zbg30v5hLu6XljNxcThUtH6taqtfq9quLqNIXRoFqUujLoVOa1DTT1880lUHT6brrk71rup1LBaLvny0m7Jzbfae3aLc3ame04PPxZrKdXlluOZL35a11bdlbZ3PypGnR5Urto0keXpUsb8fI3peOtC8pr9VC0f1LEGdpVermrdWPBMli+VSu93SPkyv/rRb5zJzNO3Odg7z+1mrakDr0of9B7s10IPdGhQ6rbzfr8t5e3roPw931QOfrL/yzJJybLYrz1SMq+2UKKlS9SPfddddevfddzV06FCtXLlSUl7wGThwoJKTk7Vy5UrVqVOn+IWUEy8vL3Xq1EnLl1/qHrXZbFq+fLlDT5AzBfsXv19zyq2tdeC1mzWqTxP7BzT/57RDeHU1D63mzBKBIrnHORmVU88mwXqgW4MSH390JYVt3PN/V9x7Xbhev7t9ubyWO/H1qlqi4ONKVapYHAKIv7WqFj11veY+0vWqw3Fl0atpcIl7ht3lbK9Sf6oeeeQRTZo0SUOGDNHKlSs1aNAgJSUlacWKFQoLK3jqqTONHTtWH330kebMmaPdu3friSeeUHp6uv72t79VyOvfVMwv18duaKzhPRoWODalSr5/Eje5HAIAF3P2r3uncpPSy/PrODzIVz2aBJfrDT6drgQNUJLjiq7Z8CPlHVfzxBNPqG/fvjpy5IhWrlypevUqPuHec889euONN/Tiiy+qQ4cOiomJ0eLFi1W7dsV0p/9zcKsip024uWWh49vmO+ukfk3fcq8JKCk3+lo2JcfdRe6xQSlMZc5tE/+S9x1+c9vQUh/vY0bvDI3UjHs7FDuPu4SfUh3zc8cddzgMe3p6Kjg4WE899ZTD+O++++7qKyuh0aNHa/To0RX2evn5W6sqfupgTf5hZ4mvY/L63e007JMNqu7rqYe5ABqAIuQPDfQSO8fDvRrptg5hCrqKU7OvFUYJAnagj6eGdKir137ereTUSwcl94ioqaFd6statcpVHexckUoVfi4/XXzo0KHlWoy7quHr+I/TopjjeOrV8NXyZ3q7dzc2AKe7Vr4hKvt61PR3/sG17qA0Afu7/+upX/cc18DWofKzesjXy/3ukV6qimfPnu2sOtxau3qOoXDm/R2LnZ/gA6A03Lnnh++7a0/d6j5Fnn3mLtwvrlVCUc1D9NgNjRV/Kl0vDWmj2gHu0e0Hc2ObVLkRGgDnKXH4SUhIUP369Uu84CNHjqhu3bplKsrdWCyWIg9wBoCrVZLjMSorIhwqoxKf7XXdddfpscce08aNRV/qOiUlRR999JHatGmjb7/9tlwKhPPx5QRUPvxfoiK5b7wumxL3/OzatUuvvvqqbrrpJnl7e6tTp04KCwuTt7e3zpw5o127dmnnzp3q2LGjpk2bpptvvtmZdQOAabj3MT+urgAoqMQ9PzVr1tRbb72lo0eP6r333lPTpk118uRJ7d+fd4fb+++/X5s3b9batWsJPm7Gjb9XcVXYKlVq18jbU5bbWwDOVuoDnn18fHTXXXfprrvuckY9AIDL8AMFzubOvYtlUblvmgIAJnWt9Jew2wuVEeEHMKkAb6504S7M9qsccDbCD2BSTWtX01/a1VGgj6fmPNTF1eXgMlznBxXJnS+nUBb89ANM7L37OirXZnBTx0roqb5N9dKPuyRJd3Zy32umVSHEoRIi/AAmR/CpnB7s3kAeVSwK9PFUj4hgV5dTZl5Vq6hLwyBtiD+tJ29s4upyAEnlFH6Sk5O1a9cu+2Pnzp3avXu3kpOTy2PxcDI2fUDl4+lRRcN7NHR1GeXiP490Vezxc2pZp+ibPgMV6arCT69evbR//35Vr15dzZs3V4sWLTR//nz9+OOPatq0aXnVCABwY15Vq6hVWICry0AxzHZQ/VWFn7CwMNlsNkVHR6t3796SpPnz56tLFw6eBAAAldNVne319ddf64MPPtD06dPVv39/rV+/njMUAABApVaq8LNs2TIZl/WNtW3bVgsWLNBrr72mKVOmKDk5WevXry/XIgEAgPPkPx6ra6MgF1ZSMUq122vAgAE6evSoatWqVWBa586d9fPPP2vNmjX6xz/+IYvFomXLlpVboQAAwDk6NQjSmH7NtOdYql68pZWry3G6UoWfy3t9CtOzZ08tX75cK1asKHNRAACgYj3VzzwnKjntCs99+vRx1qIBAADKrNThZ9asWVq+fLnOnDnjjHoAAACcqtSnur/33nuaMmWKLBaLwsPD1bFjR4dHaGioM+qEE3GGHgDATEodfnbu3KmcnBxt3bpVW7Zs0ZYtW/TRRx8pMTFRFotFoaGhOnLkiDNqBQAAuGqlCj8XewjCwsIUFhamwYMH26edOnVKmzdvVkxMTLkWCAAAUJ7K7WyvmjVrqn///urfv/9VFwUAAOAspTrgefHixQoMDHRWLQAAAE5Xqp4fenUAAIC7c9p1fgAAACojwg8AADAVwg8AADAVwg/EJQ4BAGZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKbiluHn1VdfVY8ePeTr66vq1au7uhwAAOBG3DL8ZGVl6e6779YTTzzh6lIAAICbKdWNTSuLKVOmSJI+/fRT1xZyjbBwlUMAgIm4Zfgpq9TUVIdhq9Uqq9XqomoAAEB+mZmZyszMtA9fvt0uL26526uswsPDFRgYaH9ER0e7uiQAAPA/0dHRDtvp8PBwp7xOpQk/48ePl8ViKfaxZ8+eq3qNxMREpaSk2B8TJkwop+oBAMDVmjBhgsN2OjEx0SmvU2l2ez3zzDMaMWJEsfM0btz4ql4jICBAAQEBV7UMAADgHBV1OEqlCT8hISEKCQlxdRkAAOAaV2nCT2kkJCTo9OnTSkhIUG5urmJiYiRJTZo0kb+/v2uLAwAAlZpbhp8XX3xRc+bMsQ9HRkZKklasWKGoqCgXVQUAANxBpTnguTQ+/fRTGYZR4EHwAQAAV+KW4Qfli4scAgDMhPADAABMhfADAABMhfADAABMhfADAABMhfADAABMhfADAABMhfADAABMhfADAABMhfADWcRVDgEA5kH4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4gbjGIQDATAg/AADAVAg/AADAVAg/AADAVAg/AADAVAg/AADAVAg/AADAVAg/AADAVAg/AADAVAg/4BqHAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfxAFguXOQQAmAfhBwAAmIpbhp/4+Hg9/PDDatSokXx8fBQREaFJkyYpKyvL1aUBAIBKrqqrCyiLPXv2yGaz6YMPPlCTJk20Y8cOjRw5Uunp6XrjjTdcXR4AAKjE3DL8DBw4UAMHDrQPN27cWHv37tWsWbMIPwAAoFhuGX4Kk5KSoqCgoGLnSU1NdRi2Wq2yWq3OLMstGIbh6hIAAFBmZqYyMzPtw5dvt8uLWx7zc7nY2Fi9++67euyxx4qdLzw8XIGBgfZHdHR0BVUIAACuJDo62mE7HR4e7pTXqVThZ/z48bJYLMU+9uzZ4/CcI0eOaODAgbr77rs1cuTIYpefmJiolJQU+2PChAnOXB0AAFAKEyZMcNhOJyYmOuV1KtVur2eeeUYjRowodp7GjRvb/05KSlKfPn3Uo0cPffjhh1dcfkBAgAICAq62TAAA4AQVdThKpQo/ISEhCgkJKdG8R44cUZ8+fdSpUyfNnj1bVapUqk4st8JFDgEAZlKpwk9JHTlyRFFRUWrQoIHeeOMNnThxwj4tNDTUhZUBAIDKzi3Dz9KlSxUbG6vY2FjVq1fPYRpnLgEAgOK45b6iESNGyDCMQh8AAADFccvwAwAAUFaEHwAAYCqEHwAAYCqEHwAAYCqEHwAAYCqEH4hLHAIAzITwAwAATIXwAwAATIXwAwAATIXwAwAATIXwAwAATIXwAwAATIXwAwAATIXwAwAATIXwA1m4yiEAwEQIPwAAwFQIPwAAwFQIPwAAwFQIPwAAwFQIPwAAwFQIPwAAwFQIPwAAwFQIPwAAwFQIP5BFXOUQAGAehB8AAGAqhB8AAGAqhB8AAGAqhB8AAGAqhB8AAGAqhB8AAGAqhB8AAGAqhB8AAGAqhB/IwjUOAQAmQvgBAACmQvgBAACmQvgBAACmQvgBAACmQvgBAACm4rbh59Zbb1X9+vXl7e2tOnXq6MEHH1RSUpKrywIAAJWc24afPn366Ouvv9bevXv17bffKi4uTnfddZerywIAAJVcVVcXUFZjxoyx/92gQQONHz9et912m7Kzs+Xp6enCygAAQGXmtuEnv9OnT+uLL75Qjx49ig0+qampDsNWq1VWq9XZ5VV6XOMQAFAZZGZmKjMz0z58+Xa7vLjtbi9JGjdunPz8/FSzZk0lJCTo+++/L3b+8PBwBQYG2h/R0dEVVCkAALiS6Ohoh+10eHi4U16nUoWf8ePHy2KxFPvYs2ePff7nnntOW7du1S+//CIPDw8NGzZMhmEUufzExESlpKTYHxMmTKiI1QIAACUwYcIEh+10YmKiU16nUu32euaZZzRixIhi52ncuLH97+DgYAUHB6tZs2Zq2bKlwsPDtW7dOnXv3r3Q5wYEBCggIKA8SwYAAOWkog5HqVThJyQkRCEhIWV6rs1mkySHfYUAAACXq1Thp6TWr1+vjRs3qlevXqpRo4bi4uI0ceJERUREFNnrAwAAIFWyY35KytfXV99995369u2r5s2b6+GHH1a7du20atUqzt4CAADFcsuen7Zt2+rXX391dRkAAMANuWXPDwAAQFkRfsBVDgEApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4gSxc5RAAYCKEHwAAYCqEHwAAYCqEHwAAYCqEHwAAYCqEHwAAYCqEHwAAYCqEHwAAYCqEHwAAYCqEH8jCNQ4BACZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKZC+AEAAKZC+IHqBHrb/w7y83JhJQAAOB/hB2pQ00/P9m+mbo2DNHdkV1eXAwCAU1kMwzBcXYSzpaamKjAwUCkpKQoICHB1OQAAoASctf2m5wcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJgK4QcAAJiK24efzMxMdejQQRaLRTExMWV6/uTJk5WZmVn+xeGKaH/Xov1dj/fAtWh/13JV+7v97S2eeuop7d+/X4sWLdLWrVvVoUOHAvMUd3lsbn3hWrS/a9H+rsd74Fq0v2tdqf25vUUhFi1apF9++UVvvPGGq0sBAABuoqqrCyir5ORkjRw5UgsXLpSvr2+JnpOamuowbLVanVEaAAAog8zMTIddYJdvt8uLW4YfwzA0YsQIPf744+rcubPi4+OvOL8khYeHO4wfP368Ro0aJcl5DYziXWx32t81aH/X4z1wLdrftS5v/+joaE2dOrXAfOV+hI5RiYwbN86QVOxj9+7dxowZM4yePXsaOTk5hmEYxsGDBw1JxtatWwtdbmJi4hWXy4MHDx48ePConI/ExMRyzRuV6oDnEydO6NSpU8XO07hxY/31r3/Vf//7X1ksFvv43NxceXh46P7779ecOXMcnmOz2ZSUlKRq1ao5PAcAAFRehmEoLS1NYWFhqlKl/A5TrlThp6QSEhIcuiiTkpI0YMAAffPNN+ratavq1avnwuoAAEBl5pbH/NSvX99h2N/fX5IUERFB8AEAAMVy61PdAQAASsstd3sBAACUlVv3/KxevVq33HKLwsLCZLFYtHDhwmLn//3339WzZ0/VrFlTPj4+atGihd5++22HedLS0vT000+rQYMG8vHxUY8ePbRx40aHeQzD0Isvvqg6derIx8dH/fr10/79+8t79So9V7X/iBEjZLFYHB4DBw4s79Wr9Erb/vmtWbNGVatWLfSK6DNnzlTDhg3l7e2trl27asOGDQ7TMzIyNGrUKNWsWVP+/v668847lZycfJVr435c1f5RUVEFPv+PP/74Va6N+3FG+5dkmXz/X+Kq96A8tgFuHX7S09PVvn17zZw5s0Tz+/n5afTo0Vq9erV2796tF154QS+88II+/PBD+zyPPPKIli5dqs8//1zbt29X//791a9fPx05csQ+z7Rp0/TOO+/o/fff1/r16+Xn56cBAwYoIyOj3NexMnNV+0vSwIEDdfToUfvjyy+/LNd1cwelbf+Lzp49q2HDhqlv374Fps2bN09jx47VpEmTtGXLFrVv314DBgzQ8ePH7fOMGTNG//3vfzV//nytWrVKSUlJuuOOO656fdyNq9pfkkaOHOnw+Z82bdpVrYs7ckb7l2SZfP9f4qr3QCqHbUC5njjvQpKMBQsWlPp5t99+u/HAAw8YhmEY58+fNzw8PIwff/zRYZ6OHTsa//znPw3DMAybzWaEhoYar7/+un362bNnDavVanz55ZdlXwE3V1HtbxiGMXz4cGPIkCFXU+41pzTtf8899xgvvPCCMWnSJKN9+/YO07p06WKMGjXKPpybm2uEhYUZ0dHRhmHkfdY9PT2N+fPn2+fZvXu3IclYu3btVa+Hu6qo9jcMw+jdu7fx1FNPlUPV147yav8rLZPv/6JV1HtgGOWzDXDrnp+rtXXrVv3xxx/q3bu3JCknJ0e5ubny9vZ2mM/Hx0e///67JOngwYM6duyY+vXrZ58eGBiorl27au3atRVX/DWgLO1/0cqVK1WrVi01b95cTzzxxBWvD4U8s2fP1oEDBzRp0qQC07KysrR582aHz3aVKlXUr18/+2d78+bNys7OdpinRYsWql+/Pp//Erja9r/oiy++UHBwsNq0aaMJEybo/PnzTq/9WlBc+5cE3/9X72rfg4uudhvglqe6X6169erpxIkTysnJ0eTJk/XII49IkqpVq6bu3bvr5ZdfVsuWLVW7dm19+eWXWrt2rZo0aSJJOnbsmCSpdu3aDsusXbu2fRqKdzXtL+V1d95xxx1q1KiR4uLi9I9//EODBg3S2rVr5eHh4arVqvT279+v8ePH67ffflPVqgX/9U+ePKnc3NxCP9t79uyRlPf59/LyUvXq1QvMw+e/eOXR/pJ03333qUGDBgoLC9O2bds0btw47d27V999953T18GdXan9S4Lv/6tTHu+BVD7bAFOGn99++03nzp3TunXrNH78eDVp0kRDhw6VJH3++ed66KGHVLduXXl4eKhjx44aOnSoNm/e7OKqrx1X2/733nuv/e+2bduqXbt2ioiI0MqVKwvdh4y8K6Dfd999mjJlipo1a+bqckynPNv/0Ucftf/dtm1b1alTR3379lVcXJwiIiKuttRrEp9/1yvP96A8tgGmDD+NGjWSlNdoycnJmjx5sn3jGxERoVWrVik9PV2pqamqU6eO7rnnHjVu3FiSFBoaKinvrvJ16tSxLzM5ObnQMzdQ0NW0f2EaN26s4OBgxcbGEn6KkJaWpk2bNmnr1q0aPXq0pLzbvhiGoapVq+qXX35Rr1695OHhUeDMreTkZPvnPjQ0VFlZWTp79qxD70/+eVBQebV/Ybp27SpJio2NJfwUoSTtf+ONN15xOXz/l115vQeFKcs2wNTH/Eh5jZ+ZmVlgvJ+fn+rUqaMzZ85oyZIlGjJkiKS8DXdoaKiWL19unzc1NVXr169X9+7dK6zua0Vp278whw8f1qlTpxy+jOAoICBA27dvV0xMjP3x+OOPq3nz5oqJiVHXrl3l5eWlTp06OXy2bTabli9fbv9sd+rUSZ6eng7z7N27VwkJCXz+i1Fe7V+YmJgYSeLzX4yStH9J8P1fduX1HhSmLNsAt+75OXfunGJjY+3DBw8eVExMjIKCglS/fn1NmDBBR44c0WeffSYp7/oZ9evXV4sWLSTlXU/gjTfe0JNPPmlfxpIlS2QYhpo3b67Y2Fg999xzatGihf72t79JkiwWi55++mm98soratq0qRo1aqSJEycqLCxMt912W8WtfCXgivY/d+6cpkyZojvvvFOhoaGKi4vT888/ryZNmmjAgAEVuPauV5r2r1Klitq0aePw/Fq1asnb29th/NixYzV8+HB17txZXbp00fTp05Wenm5v/8DAQD388MMaO3asgoKCFBAQoL///e/q3r27unXrVjErXkm4ov3j4uI0d+5c3XzzzapZs6a2bdumMWPG6IYbblC7du0qZsUrCWe0/5WWyfe/I1e8B+W2Dbiqc8VcbMWKFQVuey/JGD58uGEYeafD9e7d2z7/O++8Y7Ru3drw9fU1AgICjMjISOPf//63kZuba59n3rx5RuPGjQ0vLy8jNDTUGDVqlHH27FmH17XZbMbEiRON2rVrG1ar1ejbt6+xd+/eiljlSsUV7X/+/Hmjf//+RkhIiOHp6Wk0aNDAGDlypHHs2LGKWu1Ko7Ttf7miTjN99913jfr16xteXl5Gly5djHXr1jlMv3DhgvF///d/Ro0aNQxfX1/j9ttvN44ePVqOa+YeXNH+CQkJxg033GAEBQUZVqvVaNKkifHcc88ZKSkp5bx2lZ8z2v9KyzQMvv/zc8V7UF7bAG5vAQAATMX0x/wAAABzIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAABTIfwAAIAyW716tW655RaFhYXJYrFo4cKFpV7G119/rQ4dOsjX11cNGjTQ66+/Xv6F5kP4AeD2oqKi9PTTT7u6jFI5deqUatWqpfj4+HJd7r333qs333yzXJcJFCc9PV3t27fXzJkzy/T8RYsW6f7779fjjz+uHTt26N///rfefvttvffee+VcaT6luhkGAJdRIfe7yf+YNGmSq0ssV7179zaeeuqpEs176tQpIzU11bkFlbMxY8YYjzzyiMO44cOHG0OGDCkw78X7HZ05c+aKy92+fbtRo0aNAvckBCqCJGPBggUO4zIyMoxnnnnGCAsLM3x9fY0uXboYK1assE8fOnSocddddzk855133jHq1atn2Gw2p9RJzw/gJo4ePWp/TJ8+XQEBAQ7jnn32WVeXWOGysrIkSUFBQapWrZqLqym58+fP65NPPtHDDz9c7stu06aNIiIi9J///Kfclw2UxejRo7V27Vp99dVX2rZtm+6++24NHDhQ+/fvlyRlZmbK29vb4Tk+Pj46fPiwDh065JSaCD+AmwgNDbU/AgMDZbFYHMb5+/srMzNTTz75pGrVqiVvb2/16tVLGzdutC8jKipKo0eP1ujRoxUYGKjg4GBNnDhRRr77G19pGZJks9k0bdo0NWnSRFarVfXr19err75qnxYdHa1GjRrJx8dH7du31zfffOPw/KioKD355JN6/vnnFRQUpNDQUE2ePNk+fcSIEVq1apVmzJghi8Uii8Wi+Ph4e/1PP/20goODNWDAAPvy8u/2Kq6+wtx8880aPny4fXjFihUKDg5Wbm5uyd+gUvj5559ltVrVrVu3Uj83Pj7e3ib5H1FRUfZ5brnlFn311VflWDFQNgkJCZo9e7bmz5+v66+/XhEREXr22WfVq1cvzZ49W5I0YMAAfffdd1q+fLlsNpv27dtn33V79OhRp9RF+AGuIc8//7y+/fZbzZkzR1u2bFGTJk00YMAAnT592j7PnDlzVLVqVW3YsEEzZszQW2+9pY8//rhUy5gwYYKmTp2qiRMnateuXZo7d65q164tSYqOjtZnn32m999/Xzt37tSYMWP0wAMPaNWqVQ61zpkzR35+flq/fr2mTZuml156SUuXLpUkzZgxQ927d9fIkSPtPVvh4eH253l5eWnNmjV6//33C22H4uorTN26dXXkyBH7cO/evXXhwgWtW7eupE1fKr/99ps6depUpueGh4c79Pht3bpVNWvW1A033GCfp0uXLtqwYYMyMzPLq2SgTLZv367c3Fw1a9ZM/v7+9seqVasUFxcnSRo5cqRGjx6tv/zlL/Ly8lK3bt107733SpKqVHFSTHHKzjQATjV79mwjMDDQYdy5c+cMT09P44svvrCPy8rKMsLCwoxp06YZhpF3HE3Lli0d9qOPGzfOaNmyZYmXkZqaalitVuOjjz4qUFdGRobh6+tr/PHHHw7jH374YWPo0KH24d69exu9evVymOe6664zxo0b5zDP5cf89O7d24iMjCzwuvnnLa6+okyaNMlo3ry5w7iaNWsa3333XYmXkV9cXJzx/fffFzl9yJAhxkMPPVRg/PDhww0PDw/Dz8/P4eHt7V3oMT8XLlwwunbtavzlL38xcnNz7eP//PNPQ5IRHx9fpvqBstJlx/x89dVXhoeHh7Fnzx5j//79Do+jR486PDcnJ8c4fPiwkZmZafz888+GJOP48eNOqbOqcyIVgIoWFxen7Oxs9ezZ0z7O09NTXbp00e7du+3junXrJovFYh/u3r273nzzTeXm5pZoGbt371ZmZqb69u1boIbY2FidP39eN910k8P4rKwsRUZGOoxr166dw3CdOnV0/PjxK67nlXpMiquvKJf3/MTExOjs2bPq3r17iZeR36JFi5SWlqZbb7210OkXLlwocIzDRX369NGsWbMcxq1fv14PPPBAgXkfeughpaWlaenSpQ6/kH18fCTlHVsEuFJkZKRyc3N1/PhxXX/99cXO6+Hhobp160qSvvzyS3Xv3l0hISFOqYvwA6BULm5YC3Pu3DlJ0k8//WT/ErvIarU6DHt6ejoMWywW2Wy2K76+n59fmesrSt26dXXu3DmlpqbK399fY8aM0f3336/Q0FBJ0rZt2zRq1CilpqaqcePG+uqrr3TvvffKarUqLi5Op0+f1rx589S5c2etWrVKEydOVM2aNTVv3jz9/vvvBWoODg7WmTNnily/Jk2aOIw7fPhwgfleeeUVLVmyRBs2bChwsPfFXZTO2nAA+Z07d06xsbH24YMHDyomJkZBQUFq1qyZ7r//fg0bNkxvvvmmIiMjdeLECS1fvlzt2rXT4MGDdfLkSX3zzTeKiopSRkaG/Rihy3eVlyeO+QGuEREREfZjYS7Kzs7Wxo0b1apVK/u49evXOzxv3bp1atq0qTw8PEq0jKZNm8rHx0fLly8vUEOrVq1ktVqVkJCgJk2aODwuHrNTUl5eXmU64Li4+opyMagdPnxY48aN07Fjx/Tuu+9KkjIyMnTvvffq448/1p9//qmwsDB98cUX2rZtmzp27KiNGzfqpZdesh+g2bt3b7Vr105Lly7V1q1bCw1rkZGR2rVrV6nX7aJvv/1WL730kr7++mtFREQUmL5jxw7Vq1dPwcHBZX4NoKQ2bdqkyMhIe+/u2LFjFRkZqRdffFGSNHv2bA0bNkzPPPOMmjdvrttuu00bN25U/fr17cuYM2eOOnfurJ49e2rnzp1auXKlunTp4rSa6fkBrhF+fn564okn9NxzzykoKEj169fXtGnTdP78eYdTqhMSEjR27Fg99thj2rJli9599137hrsky/D29ta4ceP0/PPPy8vLSz179tSJEye0c+dOPfzww3r22Wc1ZswY2Ww29erVSykpKVqzZo0CAgIczqi6koYNG2r9+vWKj4+Xv7+/goKCSvS8K9VXmIvh55lnntG+ffu0evVqBQQESJIWLlyoQYMGqXnz5pKkFi1aKDExURkZGXrmmWckSS1bttTnn3/u0MYNGzYsssYBAwZowoQJOnPmjGrUqFGi9bpox44dGjZsmMaNG6fWrVvr2LFjkvLC4sU2+u2339S/f/9SLRcoq6ioKIczRi/n6empKVOmaMqUKYVODw4O1tq1a51VXqEIP8A1ZOrUqbLZbHrwwQeVlpamzp07a8mSJQ4b2GHDhunChQvq0qWLPDw89NRTT+nRRx8t1TImTpyoqlWr6sUXX1RSUpLq1Kmjxx9/XJL08ssvKyQkRNHR0Tpw4ICqV6+ujh076h//+Eep1uXZZ5/V8OHD1apVK124cEEHDx4s8XOLq68wwcHBslqtOnTokFatWuWwy2737t0OPWc7d+5U3bp11bp1a3l4eEiStmzZorZt20rK6z0KCwsrtr62bduqY8eO+vrrr/XYY4+VeL2kvF/Z58+f1yuvvKJXXnnFPr53795auXKlMjIytHDhQi1evLhUywXMxGIUF9cAXFOioqLUoUMHTZ8+3dWluI33339fcXFxev311xUTE6Nhw4Zp1KhReuutt7Rjxw6lpqbqxhtv1HfffaeIiAitWbNG06dP1/z584td7k8//aTnnntOO3bsKNfTeWfNmqUFCxbol19+KbdlAtcajvkBgGI8+OCD2rVrl9q0aaPRo0dr3rx52rZtm26++WZ16tRJUVFRmjp1qv3YmzZt2ujAgQNq27Ztscf1DB48WI8++qjDWWblwdPT0368EoDC0fMDmAg9P+Xj+uuv19y5c0t9EDeAyoHwAwCl1LhxYx04cMDVZQAoI8IPAAAwFY75AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApkL4AQAApvL/AXLDh8dXlZbNAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ta[0].plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6c07cf19-3a5d-47a9-9a10-ccd9f305efb9",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "plot2",
+     "test"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkUAAAG2CAYAAABxkPLrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABuFElEQVR4nO3dd3QUVRsG8GfTE9IIaUQCoYdA6C30HiAiCiqiAgIqIiBFaQqKWIL4CVgQFJGiIoqKIj0ECAFCCwQCobfQktDSezLfH5glm2y2zu5seX7n5EBmZmfu3uzOvHPn3vfKBEEQQERERGTlbKQuABEREZEpYFBEREREBAZFRERERAAYFBEREREBYFBEREREBIBBEREREREABkVEREREABgUEREREQFgUEREREQEgEEREREREQAzDormzZsHmUym8BMcHCxfn5+fjwkTJqBGjRpwdXXF0KFDkZqaqrCP5ORkREREwMXFBb6+vpg+fTqKi4uN/VaIiIjIBNhJXQB9NG3aFLt27ZL/bmf3+O1MnToVW7ZswYYNG+Dh4YGJEydiyJAhOHDgAACgpKQEERER8Pf3x8GDB3Hnzh2MHDkS9vb2+PTTT43+XoiIiEhaMnOdEHbevHn4+++/kZCQUGldRkYGfHx8sG7dOjz77LMAgHPnzqFJkyaIi4tDx44dsW3bNjz55JO4ffs2/Pz8AADLly/HzJkzcffuXTg4OBjz7RAREZHEzLql6OLFiwgICICTkxPCwsIQGRmJ2rVrIz4+HkVFRejTp4982+DgYNSuXVseFMXFxSE0NFQeEAFAeHg4xo8fjzNnzqBVq1aVjldaWopr167B3t4eMplMvtzR0RGOjo6GfbNERESkkYKCAhQUFMh/FwQBRUVFCAoKgo1N1T2HzDYo6tChA1avXo3GjRvjzp07+PDDD9G1a1ecPn0aKSkpcHBwgKenp8Jr/Pz8kJKSAgBISUlRCIjK1petU+batWuoX7+++G+GiIiIDO7GjRuoVatWlevNNigaMGCA/P/NmzdHhw4dUKdOHfz+++9wdnY2yDHt7e0BAEeOHEHNmjXly62tpSgzMxOdvoiT/376w3AJSyOdzMxMBAYG4saNG3B3d5e6OJJhPTzCeniE9fCYJdfFwu3nsDbuuvx3VdcBKeqhYktRVlYWQkJC4ObmpvJ1ZhsUVeTp6YlGjRrh0qVL6Nu3LwoLC5Genq7QWpSamgp/f38AgL+/P44cOaKwj7LRaWXbVFT2yKxmzZoqI01rYOPoIv+/pX3ZteXu7m71dQCwHsqwHh5hPTxmiXXh5OKq9XVAynrIzMwEAIWuL8qY7ZD8irKzs3H58mXUrFkTbdq0gb29PaKjo+Xrz58/j+TkZISFhQEAwsLCkJiYiLS0NPk2UVFRcHd3R0hIiNHLT0RERNIy25aid955B4MGDUKdOnVw+/ZtfPDBB7C1tcXw4cPh4eGBsWPHYtq0afDy8oK7uzsmTZqEsLAwdOzYEQDQr18/hISEYMSIEVi4cCFSUlIwZ84cTJgwwaoehREREdEjZhsU3bx5E8OHD8f9+/fh4+ODLl264NChQ/Dx8QEALF68GDY2Nhg6dCgKCgoQHh6Ob7/9Vv56W1tbbN68GePHj0dYWBiqVauGUaNGYf78+VUesyxYsvagydrffxlHR0d88MEHVl8frIdHWA+PsB4eY108Yk71YLZ5iqSQmZkJDw8PZGRkWNzzYW0Fzdoi//+1BRESloSIiIzt481J+GH/Vfnvpn4d0PT6bTF9ioiIiIj0waCIiIiICAyKiIiIiAAwKCIiIiICwKCIiIiICACDIiIiIiIADIqIiIhIS9cf5EpdBINgUERERERaiUpKlboIBsGgiIiIiAgMioiIiIgAMCgiIiIiAsCgiIiIiAgAgyIiIiIiAAyKiIiIiAAwKCIiIiICwKCIiIiICACDIiIiIiIADIqIiIiIADAoIiIiIgLAoIiIiIgIAIMiIiIiIgAMioiIiIgAMCgiIiIiAsCgiIiIiAgAgyIiIiIiAAyKiIj0kl9UAkEQpC4GEYmAQRERkY5iL95F64+iMHzFIQZGRBaAQRERkY5GrDyC3MISHLryAHFX7ktdHCLSE4MiIiIRZOcXS10EItITgyIiIiIiMCgiIiIiAsCgiIjIZJSWCigtZYdtIqkwKCIiMgHpuYXovSgGPf63F2lZ+VIXh8gqMSgiIjKS1Mx8PL88Dm/+Eo+SCi1CC7adw9V7OUh+kIsP/02SqIRE1s1O6gIQEVmLmX+ewpFrDwAAnRsk46UOdeTrrt3Pkf//6t2cSq8lIsNjSxERkZHsv3hP/v8LKVkSloSIlGFQRERERAQGRURERsNxZUSmjUEREZEEZDKZ1EUgogoYFBERERGBQREREQAgLSsfGblFBj2GIPABGpEpY1BERFbv7J1MdIrcjY6R0UjLZOJEImvFoIiIrN6U9QkoLhWQV1SChTvOG+24eYUlbD0iMiEMiojI6mXmP35slltYbLDjlA9/opJS0WL+ToxZfdRgxyMi7TCjNRGRARWVlMJWJoONjeJos1vpeQCAPefv4kIqEzkSmQK2FBERGciltGyERUaj35J9yCssqXI7VeuIyHjYUkREZCCTfj2Be9mFuJddiB9ir0AGJnAkMmVsKSIiMpDLadny/6dlFTAgIjJxDIqIiIiIwKCIiEiBFCPk2YJEZBoYFBGR1TPWLGRMSURk2iwiKFqwYAFkMhmmTJkiX5afn48JEyagRo0acHV1xdChQ5GamqrwuuTkZERERMDFxQW+vr6YPn06iosNl6OEiKyXwPYgIpNn9kHR0aNH8d1336F58+YKy6dOnYp///0XGzZsQExMDG7fvo0hQ4bI15eUlCAiIgKFhYU4ePAg1qxZg9WrV+P999839lsgIgtQNuv9jjMpWB5zGTkFxcZrgiIiUZj1kPzs7Gy89NJLWLFiBT7++GP58oyMDKxcuRLr1q1Dr169AACrVq1CkyZNcOjQIXTs2BE7d+5EUlISdu3aBT8/P7Rs2RIfffQRZs6ciXnz5sHBwaHK42ZmZir87ujoCEdHR8O8SSIyC4Ig4FJaNsb9FA8AuJtVIHGJdCMIApbHXMHD3EJM6dMQLg5mfZkgK1VQUICCgsffwYrX7aqYdUvRhAkTEBERgT59+igsj4+PR1FRkcLy4OBg1K5dG3FxcQCAuLg4hIaGws/PT75NeHg4MjMzcebMGZXHDQwMhIeHh/wnMjJSxHdFROZq7/k0+f9X7r+qsO7nQ8nGLo5OdpxJxWfbz+H7fVfwVfQlqYtDpJPIyEiF63RgYKBGrzPbW4D169fj+PHjOHq08rxBKSkpcHBwgKenp8JyPz8/pKSkyLcpHxCVrS9bp8qNGzfg7u4u/52tRETmzWC9fbTYcflO2PnF0mW43nX2cd/LXw5dx6wBwZKVhUhXs2fPxrRp0+S/Z2ZmahQYmWVQdOPGDUyePBlRUVFwcnIy+vHd3d0VgiIiIn3deJAr//+VuzkSloTI/OnarcUsH5/Fx8cjLS0NrVu3hp2dHezs7BATE4OvvvoKdnZ28PPzQ2FhIdLT0xVel5qaCn9/fwCAv79/pdFoZb+XbUNEmhMEAf+evI0Nx26gpNS8RlqZQn/o2xn5UheByOqZZVDUu3dvJCYmIiEhQf7Ttm1bvPTSS/L/29vbIzo6Wv6a8+fPIzk5GWFhYQCAsLAwJCYmIi3tcR+AqKgouLu7IyQkxOjvicjc7b90D5N+PYHpf5zCPwm3pC6O0ZWNPlNcaPxyEJHuzPLxmZubG5o1a6awrFq1aqhRo4Z8+dixYzFt2jR4eXnB3d0dkyZNQlhYGDp27AgA6NevH0JCQjBixAgsXLgQKSkpmDNnDiZMmMA+QkQ6WH3gmvz/X0VfxJDWtaQrjIH8eiQZ64/ewNt9G6FbIx+FdQIzMxKZPbNsKdLE4sWL8eSTT2Lo0KHo1q0b/P398ddff8nX29raYvPmzbC1tUVYWBhefvlljBw5EvPnz5ew1ERkymb/lYiTN9Ix8scjou6XARWRaTDLliJl9u7dq/C7k5MTli5diqVLl1b5mjp16mDr1q0GLhkRWQvGNqZPEARcv5+L2l4usLHh801SZLEtRUREUissLpW6CFTBgm3n0ON/ezH5twSpi0ImiEEREZFIlPW1JtPy3b4rAIB/T96WuCRkihgUERGVo+sjMKWjzzSUXcCJqIlMAYMiIrJ6+gQ0ZQRB0DmgGv/zcb2PT0T6Y1BERpGRV4T46w84yoZICbYUEZkGBkVkcKWlAgZ/sx9Dl8XJn+cTERGZGgZFpLEP/z2Dzgt248Cle1q97mJaNq7dfzSv04Jt5wxRNNLT9fs5+CnuGh7kFEpdFEmwBZOIAAvKU0SGdScjD6v+y1j80g+HtXqtYLg5yEkk/ZfEIq+oBNtOp2Ddax2lLo6k9OlexM86kXljS5GF+HhzEvouisHx5IcG2X9WPvs8WLK8ohIAwMHL9yUuifkSo7M2VS2/qAQvrjiEJ7+ORVomJ88lw2BQZAGu3cvBD/uv4mJaNoZ8e1Dq4hBJ1l5SXFKKzPwivfahz5M0GWeANZiV+6/i4OX7OH0rE+9uPC11cchCMSiyAPettB8ImRapG0oKikvQZ1EM2n+yC8euPdDqtWINySfDuZCaJf9/wg3DtIgTMSgijfDu2fgSb2bgw3/P4OydTKmLYhb+iL+Ja/dzkV9UqnW/N3UEQcC6w8nqt2OfIiKzxo7WZHC8UOhm0Df7AQCrDlzDtQUREpdGPakbSjLzHvd7KxB5zrEdZ1Lx7sZEUfdJRKaHLUWkVn5RCbac4jxBpDlzbhvcfiYFSbcVW+d+PVK5leh8SlalZWLKYUJHo4o+m4qxq48irtxgg5JSAem57J5gTRgUkVpLdl3EV7svSV0MIqN5eukBhd+VdTka9PX+CtuIGwpOXn9C1P2RamPXHEP0uTQMX3EIwKOks4O+3o92n+xC9NlUiUtHxsKgiNRaHnNZr9ezTxGZm8KSUmTlFyH24l0UFpcq/QQXllR+RCfmI8RdZ9PE2xlpbd/Fu0i6k4miEgFj1xyTujhkJOxTRERWoaC4BJFbz8FGJsPsgcGwt1V9TzjyxyM4kZyOkWF1NGoFir/+ECv3cxobS5FXWCJ1EUgCbCkiUiPhRjpO3kiXuhikpxX7rmD1wWv48cBVrI27rnb7E8npAIC1cdc1autcHnMZRSUcVGAoUnfkJ8N7kFOIyG1nsVnCPqxsKSJS4UTyQzzzX0LMzZO6oNkTHhKXiHS1NTFF/v+opBSM7VJX49dKnYOJyBrM/usUdpx51H+rRS1PBHq5GL0MbCkiUmHuP48z587fnCRhSUhajIqkxsDU8pUFRABw6maGJGVgUKSDLadum1T2Wp4siEgssip/IbJ8DIp0MPPPRMRcuCt1MeRMKD4jMimCIODQlfuVsoLzO1M1ocpfpMW/mfk4fSsDT34di0+3npW6KFpjUKSjVQeuSV0EIpMl1vVL3xbZPefT8ML3hzDgy1jceJgrX3746gOtbmzYGquZS2nZmPnHKew+Z+i8Pob/g1h7DJaWlY8J645j0c7zWr922HdxOH0rE9/vu4KLqYZNcio2BkUm4qPNSRi89IDBs+QCxh9qyguKdRDz7ywIAsb9dAxhkbtxIlmzyT+VHX/SuscJELPyFTNEj/rxiMbl4UdYMy98fwi/HbuBMauPoUhJHifxWHvIYniz/kzEllN38NXuSzhw6Z5Wr80pd41JyyoQu2gGxaDIBJy6mY6V+6/i5I10jPxR3IksK3pnw0k0/3AHfjuqfnJLIqnEXb6PHWdSkZKZjxe+P1TldlsT72Dgl7H46/hNgz5ekTKwT76fi2wzmfLjXvbjC6DY88+Rce0+9zh5qFSdnqXAoEhHYp5/bz3Mk/8/NdNwUXVBcQn+iL+JohIBM//k5JZa482p0dzV8OL65i/HkXQnE9N+P2nQ8kjVn2X76Tvo9vkeNJ+3A/lF5pdMMO7yfXz47xlcv58jdVGINMKgyIqwo6L2OEUJAcDOJGnmvnrj5+MAgFIB2BB/U5Iy6KpUEDB8xSGsOnANL64QuwWc30syDAZFRCoIbB7SGINuw8oxk0doZUpLH38gbqXnqdhSF/ywkWEwKNKRKeUpIiOxoJvT9NxCLIq6gJ1nUtRvrANTqSpL+pYa65RjKn87Iilwmg8yGxm5Rfjj+E20C6qO5rU8pS6OWXv/nzPYdPLR/EIHZ/WSuDSPJd/PxZfRF/Ewt1DqohCgV4R09Z7+/YjSsvKxZNdFNOf0OpKyphZzBkUWwFqGvM/eeEo+f9XZ+f3h7GArcYnMV1lABMCkJrsdu+YoLqZli7Y/Tb4ahcWlBni8I77Ptp9DA19X9A3xM+hxxEre+OYvx/UtCt7ZcAr7LtzFOgBNA9zLrbGSk54ZOZ78EO/+lYgejX2lLope+PhMAoIgIP76A7M4EYtBrNNX+Qk9yyfiMxrruVmSjJgBkabEuHgby2trj0ldBI3dycjXex/7yiXYPHM7U8WWJLUh3x7EuZQsLI+5LHVR9MKgSALbTqdg6LI49P5iLzJyi6QujsGZcyzB0WfmLUeDRKW7zkozsoz0Yc5nFfH8cvg6Zv15CmmZ+geg9AiDIgmU3ZnmF5Xi58PX9X78VbEDpjnmMyHNCIKA6LOp2H0ulZ39K/hs+zmpi2AUxVpkir6Ulo3Ld43f+kaGdyktC+9tPI31R28YPE+XPmQAHuQUIslMWvoYFFmg4lJeLC3N9fs5yCsswb6L9zB2zTGMWX0MBy/fF2XfqoLyP+Nv4o2f4nEuxTxOaNagwXvb8PeJW2q3O3snE30WxaD3FzFq558yvwCbLbjlHyfuv3TPoH9DfVrM84pK0OuLvRj4VSw2n7qt/gUSY1BkAszufKQlQ5y+zLnOtiXewZqD11BQrHmLXvfP96Lv4hh8tu1xa8iSXRcMUTy57IJivL3hJLafScFzy+O0eq0Z/3nMwpTfEuT/v34/B4VKsn7P+utx1vq5/5yucl8r9l1Bm493Yd1hTv1jzj7eov2M9PlFJThw6Z7apwv6jD77J+E20v/rJjKx3FyEpopBkZmYt+kMev5vL45deyB1UcyKIAhIup2p8yNFsYeinryRjvG/HMcHm87gx/3XtHrtzYd5SLpjvBabzLzH/d0qTqaqjLWMgjQV+UUlWH8kGd0/34unvtlfqaWgpPRxoKSq8fiTrWfxIKcQ7240/tQ/+UUl2HMuDZn52vatNHzYre2N1/X7ORon2CwoLsFLPxzCoK/3V+oP9L8d5/HUN/tx6ma6Vsdfuf9qlesupWXhky1JiL/+AD8duo695x/NazZlfQJe+uEwpv2eoNWxtFFiZk8uGBSZAHUXk6v3crD64DVcvZeDZ7W8Y9eXqXfgu5ddoLKPxbd7L2PgV7EY9l2cSTwi2FjusYe19IEhwwieu13eGnQuJUu00VmyKn8RlyAImLfpDEavPooxq46Kuu/TtzIw6Ov9iNymfeuJtnIKivHx5iR0/3wven2xV6MW4B9ir+LApftIvJWB9/5+3IqXfD8X3+y5hFM3M/DsMvHO9YO+PoAVsVcxdFkc5v59Gq+sOorLd7Ox/b/kreVH9opOwpulpXsuYfA3+3E8+aHGr2FQpCNjXl8f5GiXyO5HFXcM2iguKcVT3xwQZV+GEJWUig6fRmPAl7FV3o18vuM8AODkzQzc17IeAdMefWbKZSPjU3VHfuTqA5O4KSjzZ/xNtPooCuuP3gAAHLuu+UXrEdWf/eeWxyHxVga+i7li0I7mgiDghe8P4Yf/zrmpmQXYmnhH7esulOvjdaLcBbv8RMiFWnSoVydPSUv59tMGDITKkeosdS+7AJ/vOI+TNzMw5NuDGr+OQZEFWhR1AYev6N8J90JqNlJMuKXotbXHUFIq4GJaNuq/u1Vt59ND5eokPbcQf5+4hfvlTkJkWIeu3Mfzy+Pw21H2XZGCVJPaKvP2hpPyfiaGUD4IuJtluO94TmEJEm9lKCwrKjGd4FNXYiZ0lVV4FGKsx2kZebp9vhgUGUlhcSleXHEI/RbHVFqn7w2cssdvcSIERaZMWV+f8p1PlSnfyW/cT/GY8lsCRq06ovWxfz92A4O/2Y89/z2XV2XHmRTM/fs0blaRbDIqKRXvbUxE8n0JklHKGede7oXvD+HItQeY+afx+64QsP6IZsGoWBmtrZYF1NnW0+pbu3T11/GbBtu3GBgUGcnauGs4ePk+LqQqNuWyc6o0Dl991GH99C3t+2HM+OMUTt7MwGg1/SAy8oow7qd4/HToOl5dozwT8Wtrj+GXw8l4ZbX2wZmpKbSAO2QyD0UlpRp3KzDkU0NTeiSpLW2uPfq8zYqH0SbT+aoDVzH8+0NIvJmhfmM1x9UUgyKRbUu8g4nrjldKVKVqckRTDYxMeRJAc+hPk1ru0eO5FNV5Yq7c1X/yzDKrD1zF4G/2I06kPEaaiEpKVZiS4Z4BH1loSpML1qU01X8Xc1LWP6eMOXxHdJWRV4QOn+7CwUv3pC6K3sw4rtKIjY4fw4y8Inz4bxLirtzHU0v3i1soFRgUiai4pBTjfzmOzafu4JlvTbeDsrGZatCnLTGCRE3vLH8+dF39RkrqtaikFPP+TcLJmxkYvuKQlqXTXcU5uXIKS5BbqNnwZEPpGBmtdps+i/YZoSTG8euRZIUkjaZ8U6OMtq0uRSUCXvzhsNrtdD3/FJeq7+hcsb+MpsztlKjPOVzXOiqfpsGYgSODIhGVzyRdoCSZmq6kCios+U5TU1LUfV5hCeb8XXWyPVXUdWI8fSsDKSJM1KmJzScN1y9BE6mZ0rdWGVtZp98rd7MrPRq+Jmm/NfUM1f9W1wvq6oPXNNi3eQWe1kTXYMxO5HJYDbHuwsT4Tkn9vRQEAZtO3kZBUSmGtqkFW13bS7U5ppr6Ly0VRAlopKhbTRNNavv2diWl4tW1x+Bkb5x7IXNrqbAUGXlF6LOo8oAOVY/wTcHBy/fQtaGP1MWQO5GcrtPrDPm5LykVEJWUAh83J4MdAxD3htjcbq0ZFFGVNP1yx168h8nrEwAAtjYyDG1TC8Cjx4l2tsZvjLx2LwcvrzyMGq6Oou5X2Yli97lU9Ar2E/U4mlL211EVxL363yOu/CLxWjGN5VxKJt769QSaPeGBL55rofNdoDXYfvqOXq0uxkreWNGra47h/McDRN+vJh8VXVt8dP0c6vrn+SP+hnz05tt9G+m4FyOT7EmHbvj4zExl5BXhnonk2FlTrpn5690XATxKFtfm410YsfKw0VtbJv+WgJsP80TNtVGVMauPaZz1W5NJPKVgDvHFyJVHcCE1G38dv2XUDuRkPGImKyxP3fknt7AY/ZfE6rhv/U9u2nz/yqez+FXDFAtVHleLsEG/0WdmcIIph0GRjsS60Mtk2s9qn5aZj7DIaIRFRuO8mlFNqhgyqdnz38UhI68IsRfvYX8VI0T2XbiLHWdSUCpyZ4IzFZKpqaNJBlpVTt/W7HhTfkvQOaGYMspONeslSIz4UIdM4eXFX3+A72IuIz236v2klfus3jZSnyhLV1RSin9Pms6s5VJ1A1i29zLOp0o3ClHM933zYS4++Oc0os+qT9RprMfbhjpOSkY+3tlwEj9pMihFCwyKTMCCbdrNgbVg+znkFpagqETQayI/dSdEsSJ8ZZlr468/xMgfj2DcT/HYmWScdPNVefOX4xptJ8aXW5OpRvRpufnw3yTdX6wjXT+DJaWPPr9Dl8Uhcts5vLdRt87lpJs1B69h0q+VZy23tuSNNx/mGf2Yhmo76fm/vVgTdx1j1xxDtoaT0xrallOGGXAxef0J/BF/E3P/Po1LaeJN5WK2QdGyZcvQvHlzuLu7w93dHWFhYdi2bZt8fX5+PiZMmIAaNWrA1dUVQ4cORWqqYvScnJyMiIgIuLi4wNfXF9OnT0dxsXE/SMUlQqUv5eoDqucuyy43Y3lGXpHBHn9oGgToct5ctvey/P+fbtV+YlRVd1dinse1qduSUkFtJ+nYi+LlVTGVx157zt9Vv1EFgiDg1yPJ+Ov440eKWzRsseOIH3F8vMXwk6Wagmv3cxCVlIqpvyUobVkX+/Mk5cez/BQj6p4EqLrpFfPcoslI7C2n7mBVheueuiKUJeAFoPTvqut7MNugqFatWliwYAHi4+Nx7Ngx9OrVC4MHD8aZM2cAAFOnTsW///6LDRs2ICYmBrdv38aQIUPkry8pKUFERAQKCwtx8OBBrFmzBqtXr8b7779v1PexKOpCpWXz/k2SPMeLrpR1PDSVi7ch5RYWo9cXe9HhU/0eaWrD1GMDdeU7eNn8E++Zmv/tOA99uuZkFxSj1NQ/WBVcUzOqbvZfiXht7TFsPHELQ0wkf5x51bBhHU9+iAnrjuvVyn3yZrpo5THboGjQoEEYOHAgGjZsiEaNGuGTTz6Bq6srDh06hIyMDKxcuRKLFi1Cr1690KZNG6xatQoHDx7EoUOPEtrt3LkTSUlJ+Pnnn9GyZUsMGDAAH330EZYuXYrCQv36SIght/Bxi4M5xRTK7rrEOMd+FX1R4XdDznytLRlkWLHvKq7fz0VGXhEmrNPscZypMmRfMzKs2xn5+O3YDfUbVqHZBzsUWu+yCoqRY8THMLoMjnjj53iNt80prNySa+yRjLP+PIV/Egzfl0tdC5ip3Kz+U8UAlIql/2z7uSpzrH2/74ra4/RVkqZCGbMNisorKSnB+vXrkZOTg7CwMMTHx6OoqAh9+vSRbxMcHIzatWsjLi4OABAXF4fQ0FD4+T0eTh0eHo7MzEx5a5MqxcXFyMzMRGZmJgoKxL+IlP88m/pdhbrvlr7lLyguqdSiVn5y10rH0yMKKy0VMO6nY+i7KEar59TlRwJeSstG24+jtDpZ68JQJzV9+qkZw+10drRWRexRl8pasw0l+pz6SZYrUjeFjiq/H72BjRqOCo3cdhaz/0rEnYw8ZOUXaZxPrLyLqVmVpmPR9WylbzBnZg2CWLb3MsZpcU4tqtC4oemca2YdFCUmJsLV1RWOjo544403sHHjRoSEhCAlJQUODg7w9PRU2N7Pzw8pKY869aakpCgERGXry9apExOzDx4eHvDw8EBkZKQ4b6gcQ/TYr/glmL85CUUiDIMVs6TFJaW4la7Yx0pdlmYxbT+Tgh1nUnExLRvjfjqm84njXnahqPOZGVPsxXvILijGR5v167St7pyta90u3mW8izQBK/er7uNozmb8eUrjbb+LuYJfjySj3+J96PBpNLp8thvbErUbJKLpJLaaUHfzJ+ZZ8+wd7SfONgRtAv5ly5brdAyzTt7YuHFjJCQkICMjA3/88QdGjRqFmBjNmsj01a17N6z8/tFQbEdHcZMEAlD4RBuylXPNwWt4tWs90fantE+Rhq8VBAFDlx3Eyf9mRG4XVB3fj2gLRyNkYC4sLsXVezlIfvB4KoTLd3MQ+oSHwY+tK0Pm//hi53lsO224UYGCAFECcjKOPefS0DLQE9WrOUhdFMll/TfQJbewRGlQZS4NMIevap7va/OpO/jmRcOUQ+z6OpH8EMv2XkbrnkOBHRfVv6ACsw6KHBwc0KBBAwBAmzZtcPToUXz55ZcYNmwYCgsLkZ6ertBalJqaCn9/fwCAv78/jhw5orC/stFpZduoYmdrB3d3d5HeiXYqfoiU3TBoehd+7NpDvNpV7yKppOmH/lJatjwgAoCj1x7ik61nMX9wU8MUrJzhKw4h/vpDeDjbKyyvGOMZ447JFJKd/XLI8PmOdp3V/lEJSWP06qMAgKT54XBxsENeYQlkMsDJ3lbcA5nbMx0tKXt3Un3b9+owatSYdK2XZ749CADYmaQ+V5MyZv34rKLS0lIUFBSgTZs2sLe3R3T041myz58/j+TkZISFhQEAwsLCkJiYiLS0xyfmqKgouLu7IyQkxOhlr0gARE9qaKoKi0ux6sBV/KXk2f6J5IeiBgkDvozFexsTKy2Pv/4QAColV7xcoV9Rng79CIgsxV/Hb+HGg1y0/3QXwiKj5Z3y39uYiP5L9klcOtOnLOa7n1OI3/XoHG8I0t+WScdsW4pmz56NAQMGoHbt2sjKysK6deuwd+9e7NixAx4eHhg7diymTZsGLy8vuLu7Y9KkSQgLC0PHjh0BAP369UNISAhGjBiBhQsXIiUlBXPmzMGECRMM8zhMS/0W74O7sx1+HxdWaV3sxccRfla+fiNDxO6sq+w5t7pDpGTmGy3p4Nk7mVq19lQcrWKJJwtlJ2pDTbkgJl06upJ+SgUBs/9KlJ93Pt16FiPD6uCXwyK1LJrKkCiR3c0qgI9b1deVGX+cwvNtA7Xap6XM/2dqjYNmGxSlpaVh5MiRuHPnDjw8PNC8eXPs2LEDffv2BQAsXrwYNjY2GDp0KAoKChAeHo5vv/1W/npbW1ts3rwZ48ePR1hYGKpVq4ZRo0Zh/vz5Gh3f0CnSM/KKkJFXhHf/SsRbvRsqrCs/oWdV00ZYyPdFJ4b8y9gYuGJ/OXxdo+GlACp1SNd1KP2205olTSwpFTB5/QmkZOTj6xdboaaHs8rtDX2yKz/nHmnmh9gr+PfUHcyJaKLzPlLLzfW38cQtjUdvacTUrpA6qPgWIredxXcxVzAyrA76N1PfNcNQ5VBn55kU9GtqvPIBj6YI2nvBtB6jm21QtHLlSpXrnZycsHTpUixdurTKberUqYOtW7eKXbRKivW4676Ylq32jkDT67Qx5rpRVtaKR71yN1vjBHGmdoo0dLCpzVQXyQ9ykZqZDz93J2TkFqHbwj06HfPwlQfqNwLw5/Gb2Pxfyv7pG07h51c7aHyMii2IYvxdNZkyhRSVZbF+bnmcxCURlyAIJtty8l3Mo5uctXHXVQZFk9efwIiOdYxVrEpe/yke1xZEGO14giDg+e/icOOB8adZUcVsgyJz8F3MZQTXdMdbv54QdSJQMRnjPPJDrGLLR68vNB8heOVuDq7c0zxf0PbTKQa72RQE5Z2gyzqhSmHJrouIHBKKlfuvGLy/04Vy+WDKJvlNvp9b1eYKxJzehKSz5dQdXBRxnimx3M0ugK+bk2j723nGQCMvVZyb/km4DSc7zTuum+t0N2Vn0My8YpWfJaneHYMiA4rUcqJXZaSYrFBsuUqyyGrjxRWHNd7WkAkTj11/iGv3TSv3UNmJsUiiTvkRX8VqtJ0hsnyb60XBnJWfb8qUiD1i8/WfDHMeUfeJ1ScbufZHq5ohb5ZN/VvLoMjKiXEyMfTFyZRa2ZTNKm4KqvorpucWwtPFcLllslRMAVH+xFpxQIC+n5m0zHysiLXcpIJk/m4+zDVoC6khHxeq+nqeuZ2Bnw9dN9ixpcagSEeHrjxAVn4R3Jzs1W9MZGC305W3KGbkFcHTxQFf7tI+iVlFYoa+YQt26/V6Q93JE+mrrO/m00sP4F625fV7i/hqv16vFwTTbuW1qDxFxvb5jvMoLnmUCVlKBUWVO3KL8ZnTdB8V71iOJz/U/+Cklb/VTDCpamoMKfqn6jvpbILI83uRZfgn4RZ6/W+v1MUAAKUBkRSxgC4Dfao6J4hxbl+86wL6Ld6H+zmqzwFSdZtnS5Ee1sZdx9q4R82I7w4MxsiwIEnK8f2+yxptZ6wvpKWNbDGWyK1ndXqdse66yk96q4mV+6/it6M38OULrQxUIrI0+n6SJ69PEKMYFkXMR/5iZfS/mJYtHwlpathSJJJPt+rfqVpXewyUrl3jof7lLspX7+UYdQJXS/KdhvmJKpr6W4Jex9U0pvpHTWtURRdSs3E8OR1ddUwVQKSNRVGmP1HwVSMO1Cj7XhtyDkN9nC83mtWUsKXIQt1Kz9Msd4eK1Sb82Jf+s/6o/qNVjJG/ikgT+jwy+Spa/35zhjb3b83zkJkiY87LWKzi5jqtXAJRsbGlyAzo8jH8I/4m3tlQeQZnsi7Dvz+k9o5M1xMdZ7knsVlCeC7mzeTw7w/pPAemPsUwRvCj7n798x3nlS7PLyrBu0qS3BYWi3M+YlBkBnT9cP95/CaAR5Od/pNwC8Ul2s9LRubtdkY+wtVM1KlrR+uG723T7YVklThXnfbirtzX+fGXPt0YlN3wLNt7Gfe17FdoCF0+24NdZ1MrLc/KFyd1C4MiM/BATS99VW6l52HosoOYvD4Bqw5ql9fFRLPmk8juZBiuKZqozAod+8yZGwEQdUSyulFaVVl/RLdJerMLipX2b/xs+zl8YQL9trQd8KEtBkVmYMzqYzq/tnO5fDBLtMxVwz5FRCQWU7igGkPc5XvoKWJagJyCEvx+7AYupWnXMVldmo6qLN+r2WhmfZnqTTc7Wlu5zafu4JsXH/2/sLgU3+y+CAc7G7zZo4G0BSMi0pApDRbYmijuaK/Ptus2slnXoONhrnESTpYo6c6hj1GrjqBFLU+998OgiHDw0j10auCNVQeu4qvdlwA8CpD6hPhJXDIisiSnbqajno+rym3yi0rw65FkPOHprPF+M3JNZyogU2HqLf23RX5sf/pWJk7f0j+PEoMiwt8Jt9CxXg38Vm5491e7L2FD/E2NXm/i3z0iMhFPfXMAdb2rqdxm2d7L+FLL4fV9F6seTECaySsssfrzOYMiQvz1h2j/6a5KaenZAZeIxKaqE7IgAF/uNv18Q+ZAl8dnf8Trn/fM3DEoIly+q99Iib0GyqhNRNblXIo400hYg1tVTAKtjwKRcv2YM44+IyIik7DrbJrURbAoOQXFUhfB7DAoEtGbvxyXughERERIzy1Cx0+jpS6G2WFQJKLd53iXQ0REpiFLh5aixJsZBiiJ+WBQRERERACAxFsMioiIiMjKZeazDxKDIiIiIsJXWuaHskQMioiIiIjAoIiIiIgIAIMiIiIiIgAMioiIiIgAMCgiIiIiAsCgiIiIiAgAgyIiIiIiAICdri8sKipCSkoKcnNz4ePjAy8vLzHLRURERGRUWrUUZWVlYdmyZejevTvc3d0RFBSEJk2awMfHB3Xq1MFrr72Go0ePGqqsRERERAajcVC0aNEiBAUFYdWqVejTpw/+/vtvJCQk4MKFC4iLi8MHH3yA4uJi9OvXD/3798fFi8yMSUREROZD48dnR48exb59+9C0aVOl69u3b48xY8Zg2bJlWL16NWJjY9GwYUPRCkpERERkSBoHRb/++qtG2xUXF+ONN97QuUBEREREUtCqT9HixYtVrs/KykJ4eLheBSIiIiKSglZB0bvvvou1a9cqXZeTk4P+/fvj/v37ohSMiIiIyJi0Cop++uknjBs3Dps2bVJYnpOTg/DwcNy9exd79uwRtYBERERExqBVnqJnn30W6enpGD58OLZs2YIePXrIW4hSU1MRExODmjVrGqqsRERERAajdfLGV199FQ8ePMDgwYPxzz//4P3338ft27cRExODgIAAQ5SRiIiIyOB0ymg9Y8YMPHjwAL1790ZQUBD27t2LWrVqiV02IiIiIqPRKigaMmSIwu/29vbw9vbG5MmTFZb/9ddf+peMiIiIyIi0Coo8PDwUfh8+fLiohSEiIiKSilZB0apVqwxVDiIiIiJJ6dSnCADy8/Nx6tQppKWlobS0VL5cJpNh0KBBohSOiIiIyFh0Coq2b9+OESNGKE3UKJPJUFJSonfBiIiIiIxJq+SNZSZNmoTnn38ed+7cQWlpqcIPAyIiIiIyRzoFRampqZg2bRr8/PzELg8RERGRJHQKip599lns3btX5KIQERERSUenPkXffPMNnnvuOcTGxiI0NBT29vYK69966y1RCkdERERkLDoFRb/++it27twJJycn7N27FzKZTL5OJpMxKCIiIiKzo9Pjs/feew8ffvghMjIycO3aNVy9elX+c+XKFbHLqFRkZCTatWsHNzc3+Pr64umnn8b58+cVtsnPz8eECRNQo0YNuLq6YujQoUhNTVXYJjk5GREREXBxcYGvry+mT5+O4uJio7wHIiIiMh06BUWFhYUYNmwYbGx0erkoYmJiMGHCBBw6dAhRUVEoKipCv379kJOTI99m6tSp+Pfff7FhwwbExMTg9u3bClOVlJSUICIiAoWFhTh48CDWrFmD1atX4/3335fiLREREZGEZIIgCNq+aOrUqfDx8cG7775riDLp5O7du/D19UVMTAy6deuGjIwM+Pj4YN26dXj22WcBAOfOnUOTJk0QFxeHjh07Ytu2bXjyySdx+/Zt+Ui65cuXY+bMmbh79y4cHBwUjpGZmQkPDw8ETvkdNo4uRn+PREREpL3SglzcWPI8MjIy4O7uXuV2OvUpKikpwcKFC7Fjxw40b968UkfrRYsW6bJbvWRkZAAAvLy8AADx8fEoKipCnz595NsEBwejdu3a8qAoLi4OoaGhCqkFwsPDMX78eJw5cwatWrUy7psgIiIiyegUFCUmJsoDhtOnTyusK9/p2lhKS0sxZcoUdO7cGc2aNQMApKSkwMHBAZ6engrb+vn5ISUlRb5NxVxLZb+XbUNERETWQaegaM+ePWKXQy8TJkzA6dOnsX//fqmLQkRERGZKup7SIpk4cSI2b96MPXv2oFatWvLl/v7+KCwsRHp6usL2qamp8Pf3l29TcTRa2e9l2xAREZF10DgoSk5O1mrHt27d0row2hAEARMnTsTGjRuxe/du1K1bV2F9mzZtYG9vj+joaPmy8+fPIzk5GWFhYQCAsLAwJCYmIi0tTb5NVFQU3N3dERISYtDyExERkWnROChq164dxo0bh6NHj1a5TUZGBlasWIFmzZrhzz//FKWAVZkwYQJ+/vlnrFu3Dm5ubkhJSUFKSgry8vIAAB4eHhg7diymTZuGPXv2ID4+HqNHj0ZYWBg6duwIAOjXrx9CQkIwYsQInDx5Ejt27MCcOXMwYcIEODo6GrT8RGS5antxdCqROdK4T1FSUhI++eQT9O3bF05OTmjTpg0CAgLg5OSEhw8fIikpCWfOnEHr1q2xcOFCDBw40JDlxrJlywAAPXr0UFi+atUqvPLKKwCAxYsXw8bGBkOHDkVBQQHCw8Px7bffyre1tbXF5s2bMX78eISFhaFatWoYNWoU5s+fb9CyExERkenROk9RXl4etmzZgv379+P69evIy8uDt7c3WrVqhfDwcPnoL0vEPEVEpIl1r3bAiz8clroYRPQfg+UpcnZ2xrPPPitPiEhERIrC6tfAhjfC8NzyOKmLQkRaMPvRZ0REpkYmk6FdkJfUxSAiLTEoIiIiIgKDIiIiIiIADIqIiIiIADAoIiIiIgKg49xnFaWmpiIpKUn+c+bMGZw9e7bSFBpEREREpkqvoKhLly64ePEiPD090bhxYwQHB2PDhg3YvHkzGjZsKFYZiYjMRo/GPlIXgYh0pFdQFBAQgNLSUkRGRqJ79+4AgA0bNqB9+/aiFI6IyFw837YWOtStgT5N/KQuChHpSK8+Rb///ju+++47LFmyBP369cPhw4chk8nEKhsRkdnwdXPC0Da14OFiL3VRiEhHWgVFu3btQsVZQUJDQ7Fx40Z8+umn+PDDD5GamorDh5nenoisy+jOQVIXgYj0pFVQFB4ejrt37ypd17ZtW2zduhU7d+7Eu+++iz59+ohSQCIic1DD1VHqIhCRnrTqU6TJ3LGdO3dGdHQ09uzZo3OhiIiIiIzNYHmKevbsaahdExEREYlO66Bo2bJliI6OxsOHDw1RHiIiIiJJaD0k/5tvvsGHH34ImUyGwMBAtG7dWuHH39/fEOUkIiIiMiitg6IzZ86guLgYJ06cwPHjx3H8+HGsWLECN27cgEwmg7+/P27dumWIshIRmaTaXi4ab/vlCy0xeX2C4QpDRDrTKigqy0EUEBCAgIAAREREyNfdv38f8fHxSEhIELWARESm7uexHTTedlDzAFR3cYCvuyP6L4k1YKmISFuijT6rUaMG+vXrh379+uldKCIic1K7huYtRTY2MnRrVHkqkJFhdXDmdiYupGYhK79YzOIRkYa06mi9fft2eHh4GKosRERWa0b/YPw5vhOC/d2kLgqR1dKqpYitQEREhqVBOjgiMhCD5SkiIiIiMicMioiIDGT5y63hZM/TLJG54LeViMhA+jeriYT3q+520MDXVf5/JzuejomkpnWeIiIi0pyTvW2V61aPboef4q6jV7Av7GwfBUX/ZT4hIgkwKCIikkit6i6YPbCJ1MUgov+wvZaIiIgIDIqIiIiIADAoIiIiIgLAoIiIiIgIAIMiIiIiIgAMioiIDO7Dp5rCxcEWU/s0krooRKQCh+QTERnYqE5BeLljHdjaMAkRkSljSxERkREwICIyfQyKiIiIiMCgiIhII+8ODDbKcWRgixKRVBgUERGpEejljFc61ZW6GERkYAyKiIjUeLZ1IByqmMW+fZCXkUtDRIbCoIiISA9fv9hK6iIQkUgYFBER6WhUWB34uTuJuk8Bgqj7IyLNMSgiIjJR3q4O+GhwU6mLQWQ1GBQREZmQ8qPPano4Y0RYkHSFIbIyDIqIiIiIwKCIiEhnvZv4SV0EIhIRgyIiIh28N7AJujXykboYRCQiBkVERDoY1SnIaMdytrc12rGIrBmDIiIiHciMMBtH2fD8pS8xFxKRMTAoIiIyJUqCrRrVHI1fDiIrxKCISAIRzWtKXQTSglETKup4qK+GszWJgBEd66BpgLvUxTBbDIqIJGBvw5nQST2ZsmajKrg6st8RAS0CPbHlra5SF8NsmW1QtG/fPgwaNAgBAQGQyWT4+++/FdYLgoD3338fNWvWhLOzM/r06YOLFy8qbPPgwQO89NJLcHd3h6enJ8aOHYvs7GwjvgsiMgfaBCdSqVjGZS+1lqgkRObLbIOinJwctGjRAkuXLlW6fuHChfjqq6+wfPlyHD58GNWqVUN4eDjy8/Pl27z00ks4c+YMoqKisHnzZuzbtw+vv/66sd4CWTHObmWanvB0Vrpc2eMzUw+TBoSa/yPafiHMA0XGZbZB0YABA/Dxxx/jmWeeqbROEAQsWbIEc+bMweDBg9G8eXOsXbsWt2/flrconT17Ftu3b8cPP/yADh06oEuXLvj666+xfv163L5928jvhohMQeyMnlIXQUFZMKbJSDdLnEj2+5FtpS6C2REEy/scGJPZBkWqXL16FSkpKejTp498mYeHBzp06IC4uDgAQFxcHDw9PdG27eMvXZ8+fWBjY4PDhw+r3L+Hk7TP7lvV9pT0+ETWxqiPz5Qcitc5IuOwyKAoJSUFAODnp9j06ufnJ1+XkpICX19fhfV2dnbw8vKSb1OV8z9OF7G02utYr4akxycyRx3reandxhi5hwzFHPo9mTtvVwepi6AWp57Rj0UGRYZ2JT4GvhJ+OXjqI0Or71NN6iKI7t2BTXR+rSU+miLt7Z/ZCwdn9UKbOtWlLkqVXBw4ClEfFhkU+fv7AwBSU1MVlqempsrX+fv7Iy0tTWF9cXExHjx4IN+mKu7u7nB2tBOxxNrh6ZkMjZ8xosqc7G0RUEVnfLIMFhkU1a1bF/7+/oiOjpYvy8zMxOHDhxEWFgYACAsLQ3p6OuLj4+Xb7N69G6WlpejQoYPaY7C1hvTBz495UfZoSmbOz9qItGSOrccOttqHOGYbFGVnZyMhIQEJCQkAHnWuTkhIQHJyMmQyGaZMmYKPP/4YmzZtQmJiIkaOHImAgAA8/fTTAIAmTZqgf//+eO2113DkyBEcOHAAEydOxAsvvICAgADp3hjpzN3JeK13sTN6YoUeI2NMvSWGl3tFxnx81rPx476OvYO16B/CP5rRcISX5ZLuGZCejh07hp49Hw+fnTZtGgBg1KhRWL16NWbMmIGcnBy8/vrrSE9PR5cuXbB9+3Y4OTnJX/PLL79g4sSJ6N27N2xsbDB06FB89dVXRn8vJI4WgZ6IvXjPoMcY0bEO3h3YBM4OtriQmqV0m2B/N5xLUb7OXFjrKd8UWn/GdqmLGw9zUVoqYHyP+pq/0Fr/aEbywaAQqYtAWtLlZsZsg6IePXqojNZlMhnmz5+P+fPnV7mNl5cX1q1bp9PxTeHkSYoc7QzfwbB3E184q+nIuPWtrvhoSxJWHbhm8PKQ5sxldJaDnQ0+fSZU6mJQBaM715W6CJKylpjbbB+fWTNdnpNaKn93J9jIAFdHO7zZU4u7agOysZHBVcKO+KIQjPs40hg4gkx3dhLO1bfhjTAMb19b4+01Sb1AVBVeXXUk1Sni57EdYG+r+dH/HN9J4fe2JjyUVBdtgqpj/8xeODCrFzyd7RXWvdhB8xOppspfVi29W8G47qYRZJJ1axfkhcghmrecrX89TKPtPnq6ma5FEoWDrXQtggufbY7db3eX5NjGpMs5mkGRGWlRywNdGnpr9ZqK+TR+fb0jNk/qImaxJBfg6QyPCgERAHSur11dkaJXu9bF9PDGqGeGo06qEt7UghPbiXinNrVPI61fYyMDxnWvJ14h9ODj5qh2mxe1aH0Sk5+7I3oF++LvCZ0NcuOmiefbBqKej6skxzZ1DIqsjAxAsyc80KGu6TYxLxzaHMtfbqPZxiruBLo2Uh4UafokYGLPBpptqANT790i4FEfrQk9G+ClDnWkLo5olr/cBnGze2n9OnPpjySW/s1U52qraM87PbB/Zi808nUzUInEZyvRI8Hh7Wvjx1faISTAXZLjW5OBOkyKzKDIDOnz2Kasg7iyfuJnPgzXfcdqeLpUbslR5s/xnfB8u0DU9nLR+hgVO7+7O1U+5l9vdoKNhp3k3wlvjCebV/2lstXiMWZFVf0Jf+AEmAYlk8lQ00P75Htm0R9JwiL6uTsiwNPZHGqJdCXxH3dgqHaB+sBQf8x7qqnWx2FQpCspbjIMPOKtmgE7B4/RcORGk5qGvdNsXVu7PlVuSgKrMl0beOMJkbPbVq9mGnMrWVe7iOVaPKwFGvq6Yk6E7lOcAIC9BIM7mj1hui0p+sQHmrQ6vtbVuke6VWVaX80e6z7h6YxvX2oDLx3OpwyKzJA5ZgPQpHXrrzc7wcXhUWBmyPeobki9Kk1rPj5R29naYMfUbmIUyeRY4h2/OT8CU9bS+lbvhooLlLy9Z1rVQtS07hjSupbGx+rR2KfSsh9GPWrBrGrka1ndqkqTomy/qpSdC6qy8NnmWu3PVGjS6jhVw4u/NZFBhlrVDT/FCoMiM9Q0wEPqIhiEtq04FWk6Kk+TTphV8XV3Uvjd1dEOswcE67w/Mi9fD2+F6i72GNe9nlH7pNSpUQ2vdApCbS8XfPlCS/wwsi0m9dK8z5uyko7rprxT9Dcvtq50U9K5gTd2TOmGmBk9NC90BQuGaBfEqGpd/vSZUDzfNlDnsmhr45ud1G8kgje610fsjJ5qA0J96Hr+M4UbJWOkOrGsRCRGJMk95393YT0a+8Db1RH3sgukKIVRaNxvqtwfolZ1F3Rt6I0Dl+7hs6Hi30U62ytvYXKqYrkuNO17ZWicxkC5QS0C8GTzmpIkb533VFOd+khU5ZXOQdh44hbSsh6fRxr6ulZ54WnsX/Wj7bLqUPWp8fdwUrH2sc+fbQ4bmUzlSEFjVn91F3u00vOGrTxVLZazjHCD9ZYWwbSp6d3Ez+DXPrYUmSGZTIZjc/rotw8twzone9P4qCxQk69k7Zj2iJ/TF88Z8S5STPX1GCb7VAvrmbNv61td5f/XJm+XGMwxm72yItvb2mDfjJ6VV0D3mz5lqTG09VzbQAxtU0tlPRszZrdT8shQquH8YnDWsRXKFG6UbG1k2DSxs0GPYRpXOgvUvq6XZDkoKlo8rAWqOdhidOcgnZv89R2WXfE5+ks61s0L7WurbP6VyWTqOytr8d3uHfx4cs4RYeINTa/nrVnwE1avBprU1KzDqbbDqM1ZSIA75g9uiuHtA3FwVm+NXmMWI8j0oO03W4ZHrZxdtcx9pkrfJqaRB6r5E1V3MXilUxA2vKFZgkcAsFdyzhzSuhbmPmnYudCM0Wpkjgx9T8KgyECc7W1N5kP9TKtaODUvHB8Metz0LvUFwlxutns38cW7A4Pxerd6mNKnofoXaKB9kJfKJHdljw1qe7ng19c7IlSCUTgNfKVN7KbJaMWRYUGIHNJcrz5ilkTVN1rTluGyfej6/bQxUj8rdeX7dEgoGvtVftzXs7EP5j3VFO2CNM/TNrZr5e+qrY0MY7voNkJM07o11E21rn8hc2wh1QX7FOlI3QdEJlOeJ0fPg2q1uYPd45hX306h+racavu4TuO3auDYTiaT4fVuqqe70ObPMqZzXbyvZrbt/z3XAgND0xBWr4bmOxbZx09LOyFpnxBf/HjgqqRlsGYOttr1kzO166WfuxO2T+mKurO36rWfQC9njBSxhdgUNNXxJssUHp9pSp/PI1uKJFTV6A+xtAuyrHnOyoh5/jXFiVvdnOwxuOUTlUa6GZOmnWK1tfzl1vhsqPKAq6zfmp+7o1Z38iS+2jVc0L2RD+xsZFgyrKXUxdGJGC0bS4a1VJmjqfwh1r/eUaN9VkxNMOC/x951vRWn09FlEt7qLvZwtKu6vPMGhSDY33TzPwHAoudb6L0PfeI3BkU60vfrNrx9bcweqF9CNXNS8XGdLh/ab19qLUpZyrfU/PJqB0lnANdEnRqWM/dY/2Y1Mayd8scCf7zRCRveCMO2yd0MkizQnPMU6U3JW3/8qEx5vawe3Q7H3++Lp1s9ocHuLatu2wVVx9Q+jdCmjurg/O83O6N1bU9MD2+Mjhq07M6JaILmtTwVln3+XAt8NbwVfhunGFTpMix/y1tdVQaDr2iYRFcqv77WUaucWoCSfF16YlCko2HtzHN0U5mqTmJrx7RHIz9X0ftD6dvyumtad/k8Ngq70uFc3L2RD9aMaY/1r3dEi0BP+OrZJ0WbIpQfKeWiYRLJsV3qomWgp6jl0Eegl/gJ1L4f0QbNnvBAuyAveRbaZSIFwdZC7L+/TCYTvwuAyN7ppzrJoa6tXEtfbI3JGvQhbBHoib/e7IwJGsyT2CvYF68q6Z/k6miHp1oEwNetcuusmxYt2YNbBiBA5Az75Rnj4VnHetq3EL/Zoz6GahlIqcKgSEejOgXhrd4N0cjPsmYa7tbIBzundscb3VX3ozE2MTr+luXnkMlk6N7IR35np++X/ZnWteSP4VSdhJ3sbTCuXL1WzMhb1QS0Tva2+HtCZ7V10EKDwMlU9WtaeeRcreqK8991a+SDrg29sfRF/YOlX17tgEZ+rib3OTcUZY0HltC2M7GX6sDl6VZPoJ531S2tXw9vhZoeTpge3ljsosnV96mGj55uptNjoeUjNJwYW4nPhoYqTH6tbBTrMxq0AhqTJo88K97QO9nb4uWOiq3P5Xfz8dPN4OZop/EE36bXocJM2NvaYFrfRqjvUw2T1ycY56BaNrdI0S9uVFgd7D6fhhsP8ox/cDX8DNRPxtXRDrumdcet9Dy0ru1Z5Xb7Z/ZSmIvHr0KfoXfUnJhVnS5+GNnWoHeJpqBDXa8q78ifa1MLG+JvYmyXuli5X30H7c4NvLFzandk5RdhecxlsYtqdYzd0bp5Lc2z+rs5Pb7MuVRoeRnUIgCD/svv9fmO8+IUroK63tUwoqNunbU7N/DGvuk94eFsjxbzd2r12mHtauP5toHYmZSK/RfvKR3x+sGgEGw8cUuj/ZW/nvQK9sXuc2lalUcsykZOq7rUvdyxDl5sXxvZ2VmYqcH+2VJEovpwcDOlyyt+aKu7qM4lZIiTrCH7Pfh7OKFNneoq73S8XQ0zdHzxsBboE2Ia+WGksvDZ5oid0VPviU+tnbmMMCo/1VFV87GV+d9zLWBvK4OjnY1Zfj5q13CBR4VM95qOJpbJZAhv6o+Pnm5WqeUVADxdHBCiYR608mykGG6oz4gyLfqNMigyJxU+iGVN/33N8IL4Ro/68HN/HCQ83dJ6sjGLbXAL02oC15auiTzLk8lkCPRyEWXE0ZyIJqjnYzmd2wHDPyqT8lHcqtHtVK5v6OeGg7N649Ds3qjpUXVravmbFjcT70v1spLvTJCOAzI0TQ6rSLrgWdnNbcVYXp9rIoMiPXVuoFs22AEiZB+e2b8xdk3rjuUv6/7cWVPaXGuUfWg71388MmN4+0C4OtohdkYv7JrWDV++0BKfPCNtXhxzVtVdkDHvipWlNgjQ8HGl2NOTlCVzDPBwUph2QlmSR2Wn9le71sPut3ugttfjO+uKjzrJdAQqaQGpyMfNUW2m+/Wvd8QzrZ7A0hdbw1nDQRCaMXzI2Kq2J8b30K1/nDm2nqnzdj/d+4ixT5GevF0d8ef4TriQmoWvoy/idka+yu2fahGA9nW90K2Rj8rtNCGTyVR2vq049FNKwTXdsej5FrhyNwev//ds28HOBg183dDAt+qJJpXp1tAHfx6/CQBoqcV7NLUEc4am652jOuXvylrU8sDglk+gV7Avevxvr8J2HevVwF/l+it88ZzyjqZizzb/5xudsO30HUQ0r4nsgmJ8suUsujX00Tr30vcj22DkyiOoVd0Zz7URb3SLFJS1oMmH5Bto/8Yi1qEb+LpisZnmZNr4pu7zgamdFkkp0z6Z6pN/jkGRCNrUqY42dapjxb4r8mXKPjJH3u1t1IR8k0XO36AvbfJPqOraMPfJJniQUwBXJ3u80jlIlH2aK29XXU5o2lF1+vNxc8KYKqY7sKswUeuQ1sZ5zFe7hovCKL+fxnbQaT/B/u6Im91b9KDN1ITVr4GYC3cBAD0a+6rZ2vRY4vfaFEk9NVSwkmlbHhOvbAyKjMiYAZGPm6OoTcDanHgMfdPo6eKAVaPbi7a/8Kb+WH3wGoBHI0UKi0v1HqI7uGUAvt59SYTSqdZMxcSX6ozoWAc/HbquZwmq/mBUfFylbWuCr7v0c5qZU0Ckbf2WbT2mc11cTM1GQXEJpvVVnfdH3b7IOqj7qHm62CM9t0iUY7UM9ISbkx1eUzEDhJiBMYMiMknGbI1/J7wxMvKKUM3RFh8+1UyUC6G2jwQNQV2z+OyBwbCzlWHVgWto4OuKS2nZSrereL7R9G9Tvk9O0wDtO3Maox+PJV3MVY0cU/U+Hexs8IUIUytIxdoeiwOmPznrxJ4N4O5kjwZ+rvgq+iL2nn/UEmlrI0NJqfoIZsGQUKw7koypfRuhp5FbL9nR2oyobj4kdao6j7g62mHxsJb4+OlQk24ZUDb1harSOtrZqJ2P6YNBTXHyg35apcrX5K6sga8rnm0TiG6NfFDPpxq+qZBwsfww4EAv9R1lybSZ+DWadPBihRFu2rTGONrb4vl2gWhdW3H+TU0/Ji+0r41NE7toHBDV93nct7ZnY/366zIoElH5EVQz+ms2TcaWt7pgePtANFYR8DR7wh1NA9wxe6B4U28Y/STG5/56+/y55pWWqapWJ3sbjeZjKj9CS3vKP0grR7WFrY0Ma8e0x+63e1Sa7PK7EW3wXJta+OK5FhzZZQQMWqTTUKRZD+Y++XjOxpFhj5NBtqljmIm/VY2QNrWPU/VqDlg7pj3e6tUAn1cxoENTfHwmoo71vLDhjTA42NponPuhaYAHIoc0x3sbE3E+NavSejsbGf6d2AWA6TeZkna0/Ws2DfDAnnd6IHzJPhQWlyrdZumLrTH1twR0rF9D0kd46gKdQC8XvU9eYmCsrp96PtXw+bPNqzw3TezZAJfSstV2su/SwBv7L93D2zr2aTJFITXd4exgi0m9NJteQp2RYXXg7eqAJzydUc/HFX+O74TYi3fxYnv983wZi6eLPe5lFxpk390a+YgyqptBkYhkMhnaBWk/oZ3qfRomGLKWERtNarrj7J1MAKjUWmGO6npXQ63qzrhyN0fp+ojmNdG9sQ+qadDJvnw+KYbb5k+Km6ZZ/YNVziTfItBT7fQ1ALB6dDskP8hFPR/tW1XKd8jvZ0KJbLdO7irq/uxtbTC45ePgsmzUs7FM7NkAs/5KBPDo0drOpFSt9+HubI+3+zXGrqRUZOYX4ei1h2IXU298fEYAxG1eN6UL7PKXW6NT/Rp4tUtdjR4lian8M3lj9lVydbRTuED+Pi4MdWq44JVOQUYrAxlHh7qPAhJ1yWANOcWN6uNqxs7WRqeACAAc7WyxeVIXvP9kSKVJlo2tLEt/WyMGK4bg6mgH2woXhWfb1MInzzya2La7Hi0yw9vXxspX2ilM1aINz3JTnhjiRpctRQQAlb4AYtM2x4VYJ/E6Naph3WuqOxsbir2JdNpuX9cLMdN7AoA89YA+6vm44ubDRxP+1qpu2ZPQmroVo9ri0OX76NLQW+Vdt6U/eW/2hIde6SnE8tebnRFz/i7Cm5pOi5W2wurVwAdPhaChrxtqVXfGzYd5WDAkFHa2Nnipg/YT21b1VGJCzwY6nY+c7G2x6pV22H0uDa91rXqYvq4YFBEA7SbMI+0pq11zfYK5YEgohi47CCd7W0zrp7wPiCQTRlohdyd79Gv6qJWo/FyCFTP68u9hHE94OlcatWVuvnmxFWr8Nw/cjindcONhLoL91feRHd05CKsOXAMAdGuofvorHzdHDG9fG78eSQbwaGCIpnoG+6JnsGGG6jMoMhHNa3ngl8Pi7c9NTZrziudIdR3DNTmnBvszZYA1CPB0RuyMnrCRyRSC6XWvdsCn287i6ZZPwMGOT+aNLdjfHWO71MWhK/fx2VDFx0iG+nu4OvESYsmqOdppFBABwDv9GiPAwxkNfF1Rp9wUQ6quHe8ODMbWxDvIyi/CahET8uqDn2gT8WybQBy5+hD3sgtQzdEWWxNTAOj2GMnWRoavhrfS6jVfGnjOH6n6NJD+lP3l7JTkTOrUwBubJ4nbudTQLO1TWX7YtqH8PLYDxv10DKG1PBBm5H56ZHi6zoRQzVF11mll3JzscWBWL2TmFSHA0zQexTMoMhG2NjJ5Vtm5f5/Wa18HZvbSavLLRn6uCFLTYU3f0WpSz5sjhR7BvlgT92gajZFhQdIWxgKoytisKzcne7QM9ETCjXStElhaAl1Hq3Vp6I34uX3haGfDNCEW4p8JnfH5jvMYEOoPFwfjhgWujnZ6TeAqNtMpiYV6wtMZt9LzjHpMbWcDF7u/AU+Uj/Ro5IP3BjZBWlY+JvcRMf+KAeLLoHLN3XVqWFeG6fWvd8SF1CyEmkBHXWPy0ml29Eec7MWbV5Gk1yLQEz+/qtvEyZaGQZGBrX+9IzaeuIX+aobMlle+z7ONgbpmlE+uV1PLIMoYLCGukslkKpuTxXiLYlVTaC0PjO9RHyeSHypkZrcGTva2aF7LU+piGNVMDTPuE+nL3HLiMSgysEAvF62b5Sf0aoB1R5JRVCJgxci2BinXexFNEHvxHkoFAR+b4EXQ3L5IlqCqC6Wp/CnYAikeO442JQmYw6eOQZEJ8nVzwu63eyAjr8hguTe8XR1xcFYvCBDgaKdZU/isAcH4LuYy3urdEB/+m1TldkqHn5vKlZWIiKgKDIpMVKCXCwINfAxth+m+0b0+xnWrh4LiUpVBERGR2NaMaY9VB64yMzsZFIMi0oomjzDaBXnhyj3lc3MR6coQo8/IfHRv5KPX9BJEmmCGNRLduwOboFN95i8xBn3CBHbRsV782xMpx6CIRFM23YCHi73e843xpK0C64aIzET51A9l04eYMgZFpLcRHetgePtAvNmjvsLyslF3zZ5wV5jZmMwLYzDSRllWbTcnO3TRYA4ssmyzBwbDw9ke1RxssbDC9DOmiH2KSCOqWm4+erqZ0uVTejdEz8Y+CPZ353BqIivxSqcgNPB1RQNfVyZ5JPi6OeHQ7N4oEQSTylxdFbYUWYhXu9SFva0M8wYZZu4jXfq42tjI0Kp2dZ3n0rF0vm6Pk2aaw8mCSBO2NjJ0b+SDJ0xkLiuSnrODrdmc48yjlKTWnCdDML1/Y41zDpH0atdwwZQ+DRF78R7mD24qdXFM0vNta+H3YzcBAGH1+SiGiAyLQZEFYUBkfqb0aYQp2s6LpseQs7re1XD1v3QJ9kpmujc170WEwN3JHnVquKBNnepSF4eILByDIjJJ7IGkGW3rae2Y9vjp0HX0DvaFrRlM9eDhbI85TxrmkTARUUWmf6tIRKIJ9HLBuwOboEM9zfNIMWWiZZjQ8/Ho0D5N/CQsCZHpYksRaY0DyYjMz6ReDeHr5oQg72oI8q4mdXGITBJbigAsXboUQUFBcHJyQocOHXDkyBGpi2T12DpBJC4ne1uM6hQk6VQZ5RP5EZkiqw+KfvvtN0ybNg0ffPABjh8/jhYtWiA8PBxpaWlSF42IyKL8MKqt1EUgUsnqg6JFixbhtddew+jRoxESEoLly5fDxcUFP/74o9RFIzIJfFpKYmlduzqOvtfHYPnUiPRl1X2KCgsLER8fj9mzZ8uX2djYoE+fPoiLi6vydZmZmQq/Ozo6wtHR9Od0MSe8EBNZJh83R7g4WPWlh4ygoKAABQUF8t8rXrerYtUtRffu3UNJSQn8/BRHYvj5+SElJaXK1wUGBsLDw0P+ExkZaeiiSo6dq4lILAJ7DZKBRUZGKlynAwMDNXodw3Ud3LhxA+7u7vLfraGVSJdpPsjw+GchIqps9uzZmDZtmvz3zMxMjQIjqw6KvL29YWtri9TUVIXlqamp8Pf3r/J17u7uCkERkVGx1Y6ISCVdu7VY9eMzBwcHtGnTBtHR0fJlpaWliI6ORlhYmIQlIyIiImOz6pYiAJg2bRpGjRqFtm3bon379liyZAlycnIwevRoqYtGpByfmRERGYTVB0XDhg3D3bt38f777yMlJQUtW7bE9u3bK3W+JuNix27NsJqIiMRj9UERAEycOBETJ06UuhhEREQkIavuU0RE6tX1eTxPVrC/m4QlISIyLAZFpDUZH9pYlR6NfDCsbSBa1fbE8pfbSF0csgD9m9aU//8DZrcmE8LHZ0Skkkwmw2fPNpe6GGRBPFzssWtad1y7l4MejaWboJaoIgZFZJJk7GlNZNEa+Lqiga+r1MUgUsDHZ2SS6nlXQ2O/R/1X5kQ0kbg0RERkDdhSRCZJJpPhn4mdcfVeDjv3EhGRUTAoIpPlZG+LJjU5nQoRERkHH58RERERgUEREREREQAGRURmp6ank/z/Pm7azwJNRETKMSgiMjMLhjSHp4s9vF0dMbN/sNTFISKyGOxoTWRmAr1ccGh2b9jIZHCw430NEZFYGBQRmSEne1upi0BEZHF4m0lEREQEBkVEREREABgUkQ44LRkREVkiBkVUpS9faCn//yudgiQrBxERkTGwozVVaVDzALg72aOGqwNq13CRujhEREQGxaCIqmRjI0PPYF+pi0FERGQUfHxGREREBAZFRERERAAYFBEREREBYFBEREREBIBBEREREREABkVEREREABgUEREREQFgUEREREQEgEEREREREQAGRaQDzgdLRESWiEERERERERgUEREREQFgUEREREQEgEEREREREQAGRUREREQAGBQRERERAWBQRERERASAQRERERERAAZFRERERAAYFBEREREBYFBEREREBIBBEREREREABkWkA5mMU8ISEZHlYVBEREREBAZFRERERAAYFBEREREBYFBEREREBIBBEREREREABkVEREREABgUEREREQFgUKSVgoIChX+tlbW//zIFBQWYN2+e1dcH6+ER1sMjrIfHWBePmFM9yARBEKQuhLm4efMmAgMDcePGDdSqVUvq4kjmYXoGWi3YL//92oIICUsjnczMTHh4eCAjIwPu7u5SF0cyrIdHWA+PsB4es+S6CJq1ReF3VdcBU6gHTctgli1Fn3zyCTp16gQXFxd4enoq3SY5ORkRERFwcXGBr68vpk+fjuLiYoVt9u7di9atW8PR0RENGjTA6tWrDV94IiIiMklmGRQVFhbiueeew/jx45WuLykpQUREBAoLC3Hw4EGsWbMGq1evxvvvvy/f5urVq4iIiEDPnj2RkJCAKVOm4NVXX8WOHTuM9TaIiIjIhNhJXQBdfPjhhwBQZcvOzp07kZSUhF27dsHPzw8tW7bERx99hJkzZ2LevHlwcHDA8uXLUbduXXzxxRcAgCZNmmD//v1YvHgxwsPDle637EnjnTt3FJY7OjrC0dFRpHdn+jIzM1FakKvwuzUqe9/W+v7LsB4eYT08wnp4zJLrovw1AFD9HqWoh4KCAoU+TFlZWQAeX8erJJixVatWCR4eHpWWz507V2jRooXCsitXrggAhOPHjwuCIAhdu3YVJk+erLDNjz/+KLi7u1d5vMuXLwsA+MMf/vCHP/zhjxn+3LhxQ2VcYZYtReqkpKTAz89PYVnZ7ykpKSq3yczMRF5eHpydnSvtNygoCJcvX4a9vb3CTPHW1lJERERkyiq2FAmCgKKiIgQEBKh8nckERbNmzcJnn32mcpuzZ88iODjYSCWqzMbGBvXq1ZPs+ERERGQ4JhMUvf3223jllVdUbqNpQOLv748jR44oLEtNTZWvK/u3bFn5bdzd3ZW2EhEREZFlM5mgyMfHBz4+PqLsKywsDJ988gnS0tLg6+sLAIiKioK7uztCQkLk22zdulXhdVFRUQgLCxOlDERERGRezHJIfnJyMhISEpCcnIySkhIkJCQgISEB2dnZAIB+/fohJCQEI0aMwMmTJ7Fjxw7MmTMHEyZMkPf9eeONN3DlyhXMmDED586dw7fffovff/8dU6dOlfKtERERkUTMMqP1K6+8gjVr1lRavmfPHvTo0QMAcP36dYwfPx579+5FtWrVMGrUKCxYsAB2do8bx/bu3YupU6ciKSkJtWrVwty5c9U+wiMiIiILpX7gu+X49ttvhdDQUMHNzU1wc3MTOnbsKGzdulW+Pi8vT3jzzTcFLy8voVq1asKQIUOElJQUhX1cv35dGDhwoODs7Cz4+PgI77zzjlBUVKSwzZ49e4RWrVoJDg4OQv369YVVq1YZ4+1pRVVd3L9/X5g4caLQqFEjwcnJSQgMDBQmTZokpKenK+zDEupC3WeiTGlpqdC/f38BgLBx40aFddZSDwcPHhR69uwpuLi4CG5ubkLXrl2F3Nxc+fr79+8LL774ouDm5iZ4eHgIY8aMEbKyshT2cfLkSaFLly6Co6OjUKtWLeGzzz4zyvvTlLp6uHPnjvDyyy8Lfn5+gouLi9CqVSvhjz/+UNiHJdRDRZGRkQIAhTQm1nS+LFOxHqzpXFmess9DGXM/V1pVULRp0yZhy5YtwoULF4Tz588L7777rmBvby+cPn1aEARBeOONN4TAwEAhOjpaOHbsmNCxY0ehU6dO8tcXFxcLzZo1E/r06SOcOHFC2Lp1q+Dt7S3Mnj1bvs2VK1cEFxcXYdq0aUJSUpLw9ddfC7a2tsL27duN/n5VUVUXiYmJwpAhQ4RNmzYJly5dEqKjo4WGDRsKQ4cOlb/eUupC3WeizKJFi4QBAwZU+qJbSz0cPHhQcHd3FyIjI4XTp08L586dE3777TchPz9fvo/+/fsLLVq0EA4dOiTExsYKDRo0EIYPHy5fn5GRIfj5+QkvvfSScPr0aeHXX38VnJ2dhe+++87o77cq6uqhb9++Qrt27YTDhw8Lly9fFj766CPBxsZGnv9MECyjHso7cuSIEBQUJDRv3lzhImhN50tBUF4P1nSuLFPV56GMuZ8rrSooUqZ69erCDz/8IKSnpwv29vbChg0b5OvOnj0rABDi4uIEQRCErVu3CjY2Ngp3Q8uWLRPc3d2FgoICQRAEYcaMGULTpk0VjjFs2DAhPDzcCO9GP2V1oczvv/8uODg4yKN6S66LivVw4sQJ4YknnhDu3LlT6YtuLfXQoUMHYc6cOVVum5SUJAAQjh49Kl+2bds2QSaTCbdu3RIE4VErTPXq1eX1IgiCMHPmTKFx48YGegfiKF8P1apVE9auXauw3svLS1ixYoUgCJZXD1lZWULDhg2FqKgooXv37vKLoLWdL6uqB2Us+Vyprh4s4Vxplh2txVBSUoL169cjJycHYWFhiI+PR1FREfr06SPfJjg4GLVr10ZcXBwAIC4uDqGhoQpJH8PDw5GZmYkzZ87Itym/j7JtyvZhiirWhTJlMwuX9cmyxLpQVg+5ubl48cUXsXTpUnk6h/KsoR7S0tJw+PBh+Pr6olOnTvDz80P37t2xf/9++Wvi4uLg6emJtm3bypf16dMHNjY2OHz4sHybbt26wcHBQb5NeHg4zp8/j4cPHxrvDWpI2eehU6dO+O233/DgwQOUlpZi/fr1yM/Pl/dltLR6mDBhAiIiIip9fq3tfFlVPShjyedKVfVgKedKkxmSbyyJiYkICwtDfn4+XF1dsXHjRoSEhCAhIQEODg7w9PRU2N7Pz09tFuyydaq2UZUpWypV1UVF9+7dw0cffYTXX39dvsyS6kJVPUydOhWdOnXC4MGDlb7WGurh0KFDAIB58+bhf//7H1q2bIm1a9eid+/eOH36NBo2bIiUlBR5+osydnZ28PLyUqiHunXrKmxTvq6qV69uhHepnqrPw++//45hw4ahRo0asLOzg4uLCzZu3IgGDRoAgEXVw/r163H8+HEcPXq00rqUlBSrOV+qqoeKLPlcqa4eLOVcaXVBUePGjZGQkICMjAz88ccfGDVqFGJiYqQuliSqqovygVFmZiYiIiIQEhKCefPmSVdYA6qqHi5duoTdu3fjxIkTUhfRKKqqh9LSUgDAuHHjMHr0aABAq1atEB0djR9//BGRkZFSFlt0qr4Xc+fORXp6Onbt2gVvb2/8/fffeP755xEbG4vQ0FCpiy6aGzduYPLkyYiKioKTk5PUxZGMNvVgyedKdfWwadMmizlXWl1Q5ODgIL+ra9OmDY4ePYovv/wSw4YNQ2FhIdLT0xXuflJTUxWyYFtSpuyq6uK7774D8GhW4f79+8PNzQ0bN26Evb29/LWWVBdV1YOzszMuX75c6W546NCh6Nq1K/bu3WsV9TBr1iwAqNSK2KRJEyQnJwN49B7T0tIU1hcXF+PBgwdq66Fsnamoqh5mzJiBb775BqdPn0bTpk0BAC1atEBsbCyWLl2K5cuXW0w9xMfHIy0tDa1bt5YvKykpwb59+/DNN99gx44dVnG+VFcPBQUFsLW1tfhzpbp6GD9+vMWcK622T1GZ0tJSFBQUoE2bNrC3t0d0dLR83fnz55GcnCzvTxAWFobExESFk56yTNnl91G2jTlkyi6rC+DRXU+/fv3g4OCATZs2Vbo7sOS6KKuHWbNm4dSpU/LkoAkJCQCAxYsXY9WqVQCsox6CgoIQEBCA8+fPK6y/cOEC6tSpA+DRe0xPT0d8fLx8/e7du1FaWooOHTrIt9m3bx+Kiork20RFRaFx48Ym88hImbJ6yM3NBfBoDsTybG1t5a1pllIPvXv3RmJiosJnv23btnjppZfk/7eG86W6erC1tbWKc6W6enjvvfcs51xptC7dJmDWrFlCTEyMcPXqVeHUqVPCrFmzBJlMJuzcuVMQhEdDTGvXri3s3r1bOHbsmBAWFiaEhYXJX182pLBfv35CQkKCsH37dsHHx0fpkMLp06cLZ8+eFZYuXWqSQytV1UVGRobQoUMHITQ0VLh06ZJw584d+U9xcbEgCJZTF+o+ExWhimGmll4PixcvFtzd3YUNGzYIFy9eFObMmSM4OTkJly5dku+jf//+QqtWrYTDhw8L+/fvFxo2bKgwFD09PV3w8/MTRowYIZw+fVpYv3694OLiYlJD0VXVQ2FhodCgQQOha9euwuHDh4VLly4J//vf/wSZTCZs2bJFvg9LqAdlKo42sqbzZXnl68GazpUVqRuFZ67nSqsKisaMGSPUqVNHcHBwEHx8fITevXsrXPzKkpFVr15dcHFxEZ555hnhzp07Cvu4du2aMGDAAMHZ2Vnw9vYW3n77baXJp1q2bCk4ODgI9erVM8kkXKrqYs+ePQIApT9Xr16V78MS6kLdZ6Kiil90QbCeeoiMjBRq1aoluLi4CGFhYUJsbKzC+vv37wvDhw8XXF1dBXd3d2H06NEqkxY+8cQTwoIFCwz+3rShrh4uXLggDBkyRPD19RVcXFyE5s2bVxqibwn1oEzFi6A1nS/LK18P1nSurEjboEgQzKMezHKaDyIiIiKxWX2fIiIiIiKAQRERERERAAZFRERERAAYFBEREREBYFBEREREBIBBEREREREABkVEREREABgUEREREQFgUEREREQEgEEREVmoHj16YMqUKVIXQyf379+Hr68vrl27Jl9mLu/nhRdewBdffCF1MYh0wqCIyIzJZDKVP/PmzZO6iKLSJjD466+/8NFHH+l0nEGDBqF///5K18XGxkImk+HUqVM67VsTn3zyCQYPHoygoCCDHUOV0aNHY86cOTq9ds6cOfjkk0+QkZEhcqmIDI9BEZEZu3PnjvxnyZIlcHd3V1j2zjvvSF1EoyssLAQAeHl5wc3NTad9jB07FlFRUbh582aldatWrULbtm3RvHlzvcpZldzcXKxcuRJjx441yP7VKSkpwebNm/HUU0/p9PpmzZqhfv36+Pnnn0UuGZHhMSgiMmP+/v7yHw8PD8hkMoVlrq6uKCgowFtvvQVfX184OTmhS5cuOHr0qHwfPXr0wMSJEzFx4kR4eHjA29sbc+fORfm5otXtAwBKS0uxcOFCNGjQAI6OjqhduzY++eQT+brIyEjUrVsXzs7OaNGiBf744w+F1/fo0QNvvfUWZsyYAS8vL/j7+yu0dL3yyiuIiYnBl19+KW8Ju3btmrz8U6ZMgbe3N8LDw+X7K9+qpKp8FT355JPw8fHB6tWrFZZnZ2djw4YNBg1Ytm7dCkdHR3Ts2FHldlu2bIGHhwd++eUXAI/e76RJkzBlyhRUr14dfn5+WLFiBXJycjB69Gi4ubmhQYMG2LZtm8r9Hjx4EPb29mjXrl2V2/zxxx8IDQ2Fs7MzatSogT59+iAnJ0e+ftCgQVi/fr0W75rINDAoIrJwM2bMwJ9//ok1a9bg+PHjaNCgAcLDw/HgwQP5NmvWrIGdnR2OHDmCL7/8EosWLcIPP/yg1T5mz56NBQsWYO7cuUhKSsK6devg5+cHAIiMjMTatWuxfPlynDlzBlOnTsXLL7+MmJgYhbKuWbMG1apVw+HDh7Fw4ULMnz8fUVFRAIAvv/wSYWFheO211+QtYYGBgfLXOTg44MCBA1i+fLnSelBVvors7OwwcuRIrF69WiE43LBhA0pKSjB8+HBt/gRaiY2NRZs2bVRus27dOgwfPhy//PILXnrpJfnyNWvWwNvbG0eOHMGkSZMwfvx4PPfcc+jUqROOHz+Ofv36YcSIEcjNza1y35s2bcKgQYMgk8mUrr9z5w6GDx+OMWPG4OzZs9i7dy+GDBmiUE/t27fHkSNHUFBQoOW7J5KYQEQWYdWqVYKHh4fCsuzsbMHe3l745Zdf5MsKCwuFgIAAYeHChYIgCEL37t2FJk2aCKWlpfJtZs6cKTRp0kTjfWRmZgqOjo7CihUrKpUrPz9fcHFxEQ4ePKiwfOzYscLw4cPlv3fv3l3o0qWLwjbt2rUTZs6cqbDN5MmTFbbp3r270KpVq0rHLb+tqvJV5ezZswIAYc+ePfJlXbt2FV5++WWN91HR5cuXhX/++UflNoMHDxbGjBlTaXnZ+/nmm28EDw8PYe/evZXWl6+/4uJioVq1asKIESPky+7cuSMAEOLi4qo8fsOGDYXNmzdXuT4+Pl4AIFy7dq3KbU6ePKl2GyJTxJYiIgt2+fJlFBUVoXPnzvJl9vb2aN++Pc6ePStf1rFjR4WWgbCwMFy8eBElJSUa7ePs2bMoKChA7969K5Xh0qVLyM3NRd++feHq6ir/Wbt2LS5fvqywbcV+OjVr1kRaWpra96muZUVV+aoSHByMTp064ccff5S/j9jYWL0enW3btg1JSUkqt8nLy4OTk5PSdX/88QemTp2KqKgodO/evdL68vVna2uLGjVqIDQ0VL6srGWsqjo9e/Ysbt++rbKeWrRogd69eyM0NBTPPfccVqxYgYcPHyps4+zsDAAqW6SITBGDIiLSW9lFUJns7GwAj/rAJCQkyH+SkpIq9Suyt7dX+F0mk6G0tFTt8atVq6Zz+VQZO3Ys/vzzT2RlZWHVqlWoX7++QjBy6tQpdO3aFS1atMAzzzwjf1z0zDPP4IUXXkC7du1Qv359HDt2DDExMZg7dy5WrlyJVq1aKfTBKc/b27tSkFGmVatW8PHxwY8//qjwuKqMsvorv6ws8K2qTjdt2oS+fftWGZQBj4KtqKgobNu2DSEhIfj666/RuHFjXL16Vb5N2WNVHx+fKvdDZIoYFBFZsPr168v72pQpKirC0aNHERISIl92+PBhhdcdOnQIDRs2hK2trUb7aNiwIZydnREdHV2pDCEhIXB0dERycjIaNGig8FPWJ0hTDg4OKCkp0eo16sqnyvPPPw8bGxusW7cOa9euxZgxY+SBRX5+Pl544QX88MMPOHnyJAICAuSdnk+dOoXWrVvj6NGjmD9/Pr744gt0794dzZs3R1RUFE6cOFFlINeqVasqW5Pq16+PPXv24J9//sGkSZO0ei+a+OeffzB48GC128lkMnTu3BkffvghTpw4AQcHB2zcuFG+/vTp06hVqxa8vb1FLyORIdlJXQAiMpxq1aph/PjxmD59Ory8vFC7dm0sXLgQubm5Co+BkpOTMW3aNIwbNw7Hjx/H119/LU/Ap8k+nJycMHPmTMyYMQMODg7o3Lkz7t69izNnzmDs2LF45513MHXqVJSWlqJLly7IyMjAgQMH4O7ujlGjRmn8foKCgnD48GFcu3YNrq6u8PLy0uh16spXFVdXVwwbNgyzZ89GZmYmXnnlFfm6v//+GwMGDEDjxo0BPHrcdvfuXWRnZyM/Px9vv/02AKBJkyb46aef5PWsLvdQeHg4Zs+ejYcPH6J69eqV1jdq1Ah79uxBjx49YGdnhyVLlmhUB+qkpaXh2LFj2LRpk8rtDh8+jOjoaPTr1w++vr44fPgw7t69iyZNmsi3iY2NRb9+/UQpF5ExMSgisnALFixAaWkpRowYgaysLLRt2xY7duxQuOCOHDkSeXl5aN++PWxtbTF58mS8/vrrWu1j7ty5sLOzw/vvv4/bt2+jZs2aeOONNwAAH330EXx8fBAZGYkrV67A09MTrVu3xrvvvqvVe3nnnXcwatQohISEIC8vT+GRjTqqyqfK2LFjsXLlSgwcOBABAQHy5WfPnlVobTtz5gwiIiKQmJiIpk2bwtbWFgBw/PhxhIaG4ubNmwqvr0poaChat26N33//HePGjVO6TePGjbF792706NEDtra2omSQ/vfff9G+fXu1rTvu7u7Yt28flixZgszMTNSpUwdffPEFBgwYAOBRC9rff/+N7du3610mImOTCcoeTBOR1ejRowdatmwpWouDtVi+fDkuX76Mzz//HAkJCRg5ciSOHz+OlStXYtGiRTh9+jQyMzPRq1cv/PXXX0hJScGSJUuwYcMGtfvesmULpk+fjtOnT8PGxji9HJ566il06dIFM2bM0Gs/y5Ytw8aNG7Fz506RSkZkPGwpIiLSwYgRI/D888+jWbNm8PT0xG+//QY7OzucOnUKAwcORJs2bSAIAhYuXIj69evD29sbV65cQWhoKH777TeFVqaKIiIicPHiRdy6dUvrfle66tKliyj5l+zt7fH111+LUCIi42NLEZGVY0uRuLp27Yp169YZLZghIvEwKCIiElG9evVw5coVqYtBRDpgUEREREQE5ikiIiIiAsCgiIiIiAgAgyIiIiIiAAyKiIiIiAAwKCIiIiICwKCIiIiICACDIiIiIiIADIqIiIiIADAoIiIiIgLAoIiIiIgIAIMiIiIiIgDA/wFG4MWAGiyROwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ta[0].plot(xaxis_unit=\"km/s\",yaxis_unit=\"mK\",ymin=-100,ymax=500,xmin=3000,xmax=4500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23b859ca-0f77-4a7d-8250-b91375ceacdf",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  },
+  "toc": {
+   "base_numbering": 0
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/notebooks/nb_test.py
+++ b/tests/notebooks/nb_test.py
@@ -1,0 +1,87 @@
+"""
+Functions for handling notebook tests.
+"""
+
+import random
+import string
+import nbformat
+
+from nbclient import NotebookClient
+from nbformat.v4 import new_code_cell
+
+
+class NotebookTester(NotebookClient):
+
+
+    def __init__(self, nb, **kw):
+        super().__init__(nb, **kw)
+
+
+    def get_ref(self, name: str):
+        """
+        """
+
+        cell = new_code_cell(name)
+        self.execute_cell(cell=cell, cell_index=0)
+        save_varname = random_varname()
+        code = f"""
+                import json
+                from IPython import get_ipython
+                from IPython.display import JSON
+        
+                {save_varname} = get_ipython().last_execution_result.result
+        
+                json.dumps({save_varname})
+                JSON({{"value" : {save_varname}}})
+                """
+        output = self.inject(code)
+        return output["outputs"][0]["data"]['application/json']['value']
+
+
+    def inject(self, code: str, pop: bool = False):
+        """
+        """
+
+        inject_idx = len(self.nb.cells)
+
+        code_cell = new_code_cell(code)
+        self.nb.cells.insert(inject_idx, code_cell)
+
+        out = self.execute_cell(cell=code_cell, cell_index=inject_idx)
+
+        if pop:
+            self.nb.cells.pop(inject_idx)
+
+        return out
+
+
+    def get_cell_idx_from_tag(self, tag: str):
+        """
+        """
+
+        indices = []
+
+        for i,cell in enumerate(self.nb.cells):
+            try:
+                if tag in cell["metadata"]["tags"]:
+                    indices.append(i)
+            except KeyError:
+                continue
+
+        return indices
+
+
+def random_varname(length=10):
+    """
+    Creates a random variable name as string of a given length.
+    This is used in testbook to generate temporary variables within the notebook.
+
+    Parameters
+    ----------
+        length (int)
+
+    Returns:
+    --------
+        random variable name as string of given length
+    """
+    return ''.join(random.choice(string.ascii_lowercase) for _ in range(length))

--- a/tests/notebooks/test_example_notebooks.py
+++ b/tests/notebooks/test_example_notebooks.py
@@ -1,0 +1,43 @@
+import os
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+
+from dysh import util
+
+root_dir = util.get_project_root()
+test_dir = util.get_project_testdata()
+
+def test_positionswitch():
+    """
+    """
+
+    notebook = os.path.join(root_dir, r"notebooks", r"examples", r"positionswitch-test.ipynb")
+    filename = os.path.join(test_dir, r"TGBT21A_501_11", r"TGBT21A_501_11.raw.vegas.fits")
+
+    with open(notebook) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    has_filename = False
+
+    for cell in nb["cells"]:
+        try:
+            if "wget" in cell["metadata"]["tags"]:
+                has_filename = True
+                cell["source"] = f"filename = r'{filename}'"
+        except KeyError:
+            continue
+
+    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+    exec_nb, resources = ep.preprocess(nb, {'metadata': {'path': '.'}})
+
+    print_test = False
+
+    for cell in exec_nb["cells"]:
+        try:
+            if "print_tsys" in cell["metadata"]["tags"]:
+                assert cell["outputs"][0]["text"] == 'T_sys = 17.24\n'
+                print_test = True
+        except KeyError:
+            continue
+
+    assert print_test

--- a/tests/notebooks/test_example_notebooks.py
+++ b/tests/notebooks/test_example_notebooks.py
@@ -1,43 +1,55 @@
 import os
 import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor
+import nbclient
 
+
+from . import nb_test
 from dysh import util
 
 root_dir = util.get_project_root()
 test_dir = util.get_project_testdata()
 
+# Hardcode the tag we will use to identify
+# the cell that defines which file will be
+# loaded.
+FILENAME_TAG = "wget"
+
+
 def test_positionswitch():
     """
     """
 
+    # Which notebook we will test?
     notebook = os.path.join(root_dir, r"notebooks", r"examples", r"positionswitch-test.ipynb")
+    # What file will we use during the test?
     filename = os.path.join(test_dir, r"TGBT21A_501_11", r"TGBT21A_501_11.raw.vegas.fits")
 
     with open(notebook) as f:
         nb = nbformat.read(f, as_version=4)
 
-    has_filename = False
+    nb_tester = nb_test.NotebookTester(nb)
 
-    for cell in nb["cells"]:
-        try:
-            if "wget" in cell["metadata"]["tags"]:
-                has_filename = True
-                cell["source"] = f"filename = r'{filename}'"
-        except KeyError:
-            continue
+    # Find the cell that defines the file to be loaded
+    # and modify it to point to a file in the codebase.
+    idx = nb_tester.get_cell_idx_from_tag(FILENAME_TAG)
+    assert len(idx) == 1
+    nb_tester.nb.cells[idx[0]]["source"] = f"filename = r'{filename}'"
 
-    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
-    exec_nb, resources = ep.preprocess(nb, {'metadata': {'path': '.'}})
+    # Run all cells and keep the kernel client alive.
+    nb_tester.execute(cleanup_kc=False)
 
-    print_test = False
+    # Get the value of the variable `filename`
+    # and check that it matches the `filename`
+    # we defined for the test.
+    ret_filename = nb_tester.get_ref("filename")
+    assert ret_filename == filename
 
-    for cell in exec_nb["cells"]:
-        try:
-            if "print_tsys" in cell["metadata"]["tags"]:
-                assert cell["outputs"][0]["text"] == 'T_sys = 17.24\n'
-                print_test = True
-        except KeyError:
-            continue
+    # We can also do things like this to test values.
+    tsys = nb_tester.get_ref("psscan[0].tsys.mean()")
+    assert tsys == 17.240003306306875
 
-    assert print_test
+    # We can also capture the cell output and use it
+    # for testing.
+    idx = nb_tester.get_cell_idx_from_tag("print_tsys")
+    assert len(idx) == 1 # make sure there is only one cell with the tag.
+    assert nb_tester.nb.cells[idx[0]]["outputs"][0]["text"] == 'T_sys = 17.24\n'

--- a/tests/notebooks/test_example_notebooks.py
+++ b/tests/notebooks/test_example_notebooks.py
@@ -53,3 +53,6 @@ def test_positionswitch():
     idx = nb_tester.get_cell_idx_from_tag("print_tsys")
     assert len(idx) == 1 # make sure there is only one cell with the tag.
     assert nb_tester.nb.cells[idx[0]]["outputs"][0]["text"] == 'T_sys = 17.24\n'
+
+    # Cleanup.
+    nb_tester._cleanup_kernel()


### PR DESCRIPTION
Possible way of testing notebooks using `nbconvert` and `nbformat`.
It kind of requires significant work to get started, but it does allow testing the notebooks thoroughly against the data in testdata.

For this to work we have to tag the cells in the example notebooks with meaningful names, and keep the part where we define the `filename` (the SDFITS to be loaded) in a separate cell, so `filename` can be changed to one of the files in testdata. Cells to be tested also need to be tagged so they can be identified and used to check that the notebooks works. If we decide to use this method, I'd be happy to document the process.