### PR TITLE
Fixes velocity definitions

### DIFF
--- a/src/dysh/coordinates/core.py
+++ b/src/dysh/coordinates/core.py
@@ -422,11 +422,14 @@ def veltofreq(velocity, restfreq, veldef):
         raise ValueError(f"Unrecognized VELDEF: {veldef}")
     vc = velocity / const.c
     if vdef == "radio":
-        frequency = 1.0 - vc * restfreq
+        radio = u.doppler_radio(restfreq)
+        frequency = velocity.to(u.Hz, equivalencies=radio)
     elif vdef == "optical":
-        frequency = restfreq / (1.0 + vc)
+        optical = u.doppler_optical(restfreq)
+        frequency = velocity.to(u.Hz, equivalencies=optical)
     elif vdef == "relativistic":
-        frequency = restfreq * np.sqrt((1.0 - vc) / (1.0 + vc))
+        relativistic = u.doppler_relativistic(restfreq)
+        frequency = velocity.to(u.Hz, equivalencies=relativistic)
     else:
         # should never get here.
         raise ValueError(f"Unrecognized velocity convention: {vdef}")


### PR DESCRIPTION
The equation for the radio velocity definition was mistyped. This also caused a `UnitConversionError` when trying to use baseline subtraction.