### PR TITLE
Fix: adds support for right hand side arithmetic operations on Spectrum

### DIFF
--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -603,6 +603,8 @@ class Spectrum(Spectrum1D):
         result = self._arithmetic_apply(other, op, handle_meta)
         return result
 
+    __radd__ = __add__
+
     def __sub__(self, other):
         op = self.subtract
         handle_meta = self._add_meta
@@ -614,6 +616,9 @@ class Spectrum(Spectrum1D):
         result = self._arithmetic_apply(other, op, handle_meta)
         return result
 
+    def __rsub__(self, other):
+        return -1 * (self - other)
+
     def __mul__(self, other):
         op = self.multiply
         handle_meta = self._mul_meta
@@ -621,6 +626,8 @@ class Spectrum(Spectrum1D):
             other = u.Quantity(other)
         result = self._arithmetic_apply(other, op, handle_meta)
         return result
+
+    __rmul__ = __mul__
 
     def __div__(self, other):
         op = self.divide

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -21,6 +21,7 @@ class TestSpectrum:
         assert addition.meta["EXPOSURE"] == (self.ps0.meta["EXPOSURE"] + self.ps1.meta["EXPOSURE"])
         assert np.all(addition.flux.value == (self.ps0.flux.value + self.ps1.flux.value))
         assert addition.flux.unit == self.ps0.flux.unit
+        assert addition.velocity_frame == self.ps0.velocity_frame
 
     def test_add_scalar(self):
         """Test that we can add a scalar to a `Spectrum`."""
@@ -29,6 +30,16 @@ class TestSpectrum:
         assert addition.meta["EXPOSURE"] == self.ps0.meta["EXPOSURE"]
         assert np.all(addition.flux.value == (self.ps0.flux.value + 10.0))
         assert addition.flux.unit == self.ps0.flux.unit
+        assert addition.velocity_frame == self.ps0.velocity_frame
+
+    def test_radd_scalar(self):
+        """Test that we can add a scalar to a `Spectrum`."""
+        addition = 10 + self.ps0
+
+        assert addition.meta["EXPOSURE"] == self.ps0.meta["EXPOSURE"]
+        assert np.all(addition.flux.value == (self.ps0.flux.value + 10.0))
+        assert addition.flux.unit == self.ps0.flux.unit
+        assert addition.velocity_frame == self.ps0.velocity_frame
 
     def test_sub(self):
         """Test that we can subtract two `Spectrum`."""
@@ -37,6 +48,7 @@ class TestSpectrum:
         assert subtraction.meta["EXPOSURE"] == (self.ps0.meta["EXPOSURE"] + self.ps1.meta["EXPOSURE"])
         assert np.all(subtraction.flux.value == (self.ps0.flux.value - self.ps1.flux.value))
         assert subtraction.flux.unit == self.ps0.flux.unit
+        assert subtraction.velocity_frame == self.ps0.velocity_frame
 
     def test_sub_scalar(self):
         """Test that we can subtract a scalar from a `Spectrum`."""
@@ -45,6 +57,16 @@ class TestSpectrum:
         assert subtraction.meta["EXPOSURE"] == self.ps0.meta["EXPOSURE"]
         assert np.all(subtraction.flux.value == (self.ps0.flux.value - 10.0))
         assert subtraction.flux.unit == self.ps0.flux.unit
+        assert subtraction.velocity_frame == self.ps0.velocity_frame
+
+    def test_rsub_scalar(self):
+        """Test that we can subtract a scalar from a `Spectrum`."""
+        subtraction = 10.0 - self.ps0
+
+        assert subtraction.meta["EXPOSURE"] == self.ps0.meta["EXPOSURE"]
+        assert np.all(subtraction.flux.value == (10.0 - self.ps0.flux.value))
+        assert subtraction.flux.unit == self.ps0.flux.unit
+        assert subtraction.velocity_frame == self.ps0.velocity_frame
 
     def test_mul(self):
         """Test that we can multiply two `Spectrum`."""
@@ -52,6 +74,7 @@ class TestSpectrum:
 
         assert np.all(multiplication.flux.value == (self.ps0.flux.value * self.ps1.flux.value))
         assert multiplication.flux.unit == self.ps0.flux.unit * self.ps1.flux.unit
+        assert multiplication.velocity_frame == self.ps0.velocity_frame
 
     def test_mul_scalar(self):
         """Test that we can multiply a `Spectrum` and a scalar."""
@@ -59,6 +82,15 @@ class TestSpectrum:
 
         assert np.all(multiplication.flux.value == (self.ps0.flux.value))
         assert multiplication.flux.unit == self.ps0.flux.unit
+        assert multiplication.velocity_frame == self.ps0.velocity_frame
+
+    def test_rmul_scalar(self):
+        """Test that we can multiply a `Spectrum` and a scalar."""
+        multiplication = 1.0 * self.ps0
+
+        assert np.all(multiplication.flux.value == (self.ps0.flux.value))
+        assert multiplication.flux.unit == self.ps0.flux.unit
+        assert multiplication.velocity_frame == self.ps0.velocity_frame
 
     def test_div(self):
         """Test that we can divide two `Spectrum`."""
@@ -73,3 +105,4 @@ class TestSpectrum:
 
         assert np.all(division.flux.value == (self.ps0.flux.value))
         assert division.flux.unit == self.ps0.flux.unit
+        assert division.velocity_frame == self.ps0.velocity_frame


### PR DESCRIPTION
Adds `__rmul__`, `__radd__` and `__rsub__` operations for `Spectrum` objects and tests.
This should fix issue #243. 