### PR TITLE
270 psalas review

### DIFF
--- a/notebooks/examples/dataIO.ipynb
+++ b/notebooks/examples/dataIO.ipynb
@@ -308,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ta.write(\"testwrite.fits\",format=\"fits\",overwrite=True)"
+    "ta.write(\"testwrite.fits\", format=\"fits\", overwrite=True)"
    ]
   },
   {
@@ -338,7 +338,7 @@
     }
    ],
    "source": [
-    "s1=Spectrum.read(\"testwrite.fits\",format=\"fits\")\n",
+    "s1 = Spectrum.read(\"testwrite.fits\", format=\"fits\")\n",
     "s1.plot()"
    ]
   },
@@ -360,7 +360,7 @@
     }
    ],
    "source": [
-    "s2=Spectrum.read(\"testwrite.ecsv\",format=\"ecsv\")\n",
+    "s2 = Spectrum.read(\"testwrite.ecsv\", format=\"ecsv\")\n",
     "s2.plot()"
    ]
   },
@@ -370,7 +370,7 @@
    "metadata": {},
    "source": [
     "### GBTIDL ASCII format\n",
-    "`dysh` can read text files created by GBTIDL's `write_ascii` function. However, those files do not provide sufficient metadata to to fully recreate the spectrum.  (For instance, they do not have complete sky coordinate information).  "
+    "`dysh` can read text files created by GBTIDL's `write_ascii` function. However, those files do not provide sufficient metadata to fully recreate the spectrum.  (For instance, they do not have complete sky coordinate information).  "
    ]
   },
   {
@@ -394,15 +394,14 @@
      "output_type": "stream",
      "text": [
       "Spectrum1D (length=32768)\n",
-      "Flux=[3608710. 3553598. 3604808. ... 3523171. 3545982. 3474847.] ct,  mean=493422767.43425 ct\n",
-      "Spectral Axis=[1.42009237 1.42009166 1.42009094 ... 1.39665654 1.39665582\n",
-      "               1.39665511] GHz,  mean=1.40837 GHz \n",
+      "flux:             [ 3.6087e+06 ct, ..., 3.4748e+06 ct ],  mean=nan ct\n",
+      "spectral axis:    [ 1.4201 GHz, ..., 1.3967 GHz ],  mean=1.4084 GHz \n",
       " {'SCAN': 156, 'OBJECT': 'NGC2782', 'DATE-OBS': '2021-02-10 00:00:00.000', 'RA': 119.42083333333332, 'VELDEF': 'None-HEL', 'POL': 'YY'}\n"
      ]
     }
    ],
    "source": [
-    "print(s3,\"\\n\",s3.meta)"
+    "print(s3, \"\\n\", s3.meta)"
    ]
   },
   {
@@ -437,16 +436,14 @@
      "output_type": "stream",
      "text": [
       "Spectrum1D (length=32768)\n",
-      "Flux=[-0.1042543   0.05250004  0.00432693 ... -0.05038555  0.03408394\n",
-      "       0.06139921] K,  mean=0.17345 K\n",
-      "Spectral Axis=[1281.15245599 1281.30342637 1281.45439674 ... 6227.69690405\n",
-      "               6227.84787443 6227.99884481] km / s,  mean=3754.57565 km / s \n",
+      "flux:             [ -0.10425 K, ..., 0.061399 K ],  mean=nan K\n",
+      "spectral axis:    [ 1281.2 km / s, ..., 6228.0 km / s ],  mean=3754.6 km / s \n",
       " {'SCAN': 152, 'OBJECT': 'NGC2415', 'DATE-OBS': '2021-02-10 00:00:00.000', 'RA': 114.65624999999999, 'VELDEF': 'RADI-HEL', 'POL': 'YY'}\n"
      ]
     }
    ],
    "source": [
-    "print(s4,\"\\n\",s4.meta)"
+    "print(s4, \"\\n\", s4.meta)"
    ]
   },
   {
@@ -466,7 +463,7 @@
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x7fadc0f6a460>]"
+       "[<matplotlib.lines.Line2D at 0x7f43e5cf9580>]"
       ]
      },
      "execution_count": 16,
@@ -485,9 +482,10 @@
     }
    ],
    "source": [
+    "plt.figure()\n",
     "plt.xlabel(f\"Velocity ({s4.meta['VELDEF']}) [{s4.spectral_axis.unit}]\")\n",
     "plt.ylabel(f\"$T_A$ [{s4.flux.unit}]\")\n",
-    "plt.plot(s4.spectral_axis,s4.flux)"
+    "plt.plot(s4.spectral_axis, s4.flux)"
    ]
   },
   {
@@ -514,7 +512,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psscan.write('scanblock.fits',overwrite=True)"
+    "psscan.write('scanblock.fits', overwrite=True)"
    ]
   },
   {
@@ -539,18 +537,9 @@
    "execution_count": 18,
    "id": "0c8a42c1-77e5-4aa9-88b5-ad88f7be0694",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: AstropyDeprecationWarning: The update function is deprecated and may be removed in a future version.\n",
-      "        Use update_header instead. [dysh.fits.sdfitsload]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "sdfits.write(\"mydata.fits\",plnum=1,ifnum=[0,2],intnum=np.arange(100),overwrite=True)"
+    "sdfits.write(\"mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True)"
    ]
   },
   {
@@ -675,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1f2ba8c-ca55-4bcc-84f6-5ee822900efb",
+   "id": "7fbeabb4-7072-48ba-80b9-5b4ee963f01f",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -697,7 +686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -1731,7 +1731,7 @@ class GBTFITSLoad(SDFITSLoad):
                 if len(fi) > 1:
                     p = Path(fileobj)
                     # Note this will not preserve "A","B" etc suffixes in original FITS files.
-                    outfile = p.stem + str(count) + p.suffix
+                    outfile = p.parent / (p.stem + str(count) + p.suffix)
                     count += 1
                 else:
                     outfile = fileobj

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from astropy.io import fits
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 import dysh
 from dysh import util
@@ -289,22 +289,41 @@ class TestGBTFITSLoad:
         gbtidl_index = pd.read_csv(index_file, skiprows=10, delim_whitespace=True)
         assert np.all(g._index["INTNUM"] == gbtidl_index["INT"])
 
-    def test_write_single_file(self):
+    def test_write_single_file(self, tmp_path):
         "Test that writing an SDFITS file works when subselecting data"
         p = util.get_project_testdata() / "AGBT20B_014_03.raw.vegas"
         data_file = p / "AGBT20B_014_03.raw.vegas.A6.fits"
         g = gbtfitsload.GBTFITSLoad(data_file)
-        out = "test_write_single.fits"
+        o = tmp_path / "sub"
+        o.mkdir()
+        out = o / "test_write_single.fits"
         g.write(out, plnum=1, intnum=2, overwrite=True)
         t = gbtfitsload.GBTFITSLoad(out)
         assert set(t._index["PLNUM"]) == set([1])
         # assert set(t._index["INT"]) == set([2])  # this exists because GBTIDL wrote it
         assert set(t._index["INTNUM"]) == set([2])
 
-    def test_write_multi_file(self):
+    def test_write_multi_file(self, tmp_path):
         "Test that writing multiple SDFITS files works, including subselection of data"
         f = util.get_project_testdata() / "AGBT18B_354_03/AGBT18B_354_03.raw.vegas/"
         g = gbtfitsload.GBTFITSLoad(f)
         # writes testmultia0,1,2,3.fits
-        g.write("testmulti.fits", multifile=True, scan=6, overwrite=True)
+        o = tmp_path / "sub"
+        o.mkdir()
+        output = o / "testmulti.fits"
+        g.write(output, multifile=True, scan=6, overwrite=True)
         # @todo remove test output files in a teardown method
+        sdf = gbtfitsload.GBTFITSLoad(o)
+
+    def test_write_all(self, tmp_path):
+        """Test that we can write a loaded SDFITS file without any changes"""
+        p = util.get_project_testdata() / "AGBT20B_014_03.raw.vegas"
+        data_file = p / "AGBT20B_014_03.raw.vegas.A6.fits"
+        org_sdf = gbtfitsload.GBTFITSLoad(data_file)
+        d = tmp_path / "sub"
+        d.mkdir()
+        output = d / "test_write_all.fits"
+        org_sdf.write(output, overwrite=True)
+        new_sdf = gbtfitsload.GBTFITSLoad(output)
+        # Compare the index for both SDFITS.
+        assert_frame_equal(org_sdf._index, new_sdf._index)

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -103,6 +103,7 @@ class TestGBTFITSLoad:
         hdu = fits.open(idl_file)
         table = hdu[1].data
         gbtidl_spec = table["DATA"][0]
+        hdu.close()
 
         # Do not compare NaN values.
         mask = np.isnan(ps_vals) | np.isnan(gbtidl_spec)


### PR DESCRIPTION
- Minor changes to the `dataIO` example notebook (mostly adding spaces and removing a duplicate word).
- Fixes bug that would cause writing with `multifile=True` (with `len(fi)>1`) to always end in the same directory as where the call was made.
- Adds a test for writing the same file that was loaded.
- Adds teardown for tests that write files.
