### PR TITLE
Fix: slicing of Spectrum objects

### DIFF
--- a/src/dysh/coordinates/core.py
+++ b/src/dysh/coordinates/core.py
@@ -605,7 +605,7 @@ class Observatory:
 
     def __getitem__(self, key):
         # For GBT we want to use the GBO official location
-        if key == "GBT":
+        if key == "GBT" or key == "NRAO_GBT":
             return self.GBT
         elif key == "GB20M":
             return self.GB20M
@@ -613,7 +613,7 @@ class Observatory:
 
     def __class_getitem__(self, key):
         # For GBT we want to use the GBO official location
-        if key == "GBT":
+        if key == "GBT" or key == "NRAO_GBT":
             return GBT()
         elif key == "GB20M":
             return GB20M()

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -938,6 +938,9 @@ class Spectrum(Spectrum1D):
             if "velocity" in u.get_physical_type(q):
                 # Convert from velocity to channel.
                 idx = vel2idx(q, wcs, spectral_axis, coo, sto)
+            elif "length" in u.get_physical_type(q):
+                # Convert wavelength to channel.
+                idx = wav2idx(q, wcs, spectral_axis, coo, sto)
             elif "frequency" in u.get_physical_type(q):
                 # Convert from frequency to channel.
                 idxs = wcs.world_to_pixel(coo, q, sto)
@@ -950,6 +953,12 @@ class Spectrum(Spectrum1D):
             vel_sp = spectral_axis.to(unit=vel.unit).replicate(value=vel.value, unit=vel.unit)
             with u.set_enabled_equivalencies(eq):
                 idxs = wcs.world_to_pixel(coo, vel_sp, sto)
+            return int(np.round(idxs[0]))
+
+        def wav2idx(wav, wcs, spectral_axis, coo, sto):
+            with u.set_enabled_equivalencies(u.spectral()):
+                wav_sp = spectral_axis.to(unit=wav.unit).replicate(value=wav.value, unit=wav.unit)
+                idxs = wcs.world_to_pixel(coo, wav_sp, sto)
             return int(np.round(idxs[0]))
 
         # Only slicing along the spectral coordinate.

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -789,7 +789,7 @@ class Spectrum(Spectrum1D):
                 warnings.filterwarnings("ignore", category=VerifyWarning)
                 wcs = WCS(header=meta)
                 # It would probably be safer to add NAXISi to meta.
-                wcs.array_shape = (0,0,0,len(data))
+                wcs.array_shape = (0, 0, 0, len(data))
                 # For some reason these aren't identified while creating the WCS object.
                 wcs.wcs.obsgeo[:3] = meta["SITELONG"], meta["SITELAT"], meta["SITEELEV"]
                 # Reset warnings.
@@ -946,8 +946,7 @@ class Spectrum(Spectrum1D):
             return idx
 
         def vel2idx(vel, wcs, spectral_axis, coo, sto):
-            eq = get_spectral_equivalency(spectral_axis.doppler_rest, 
-                                          spectral_axis.doppler_convention)
+            eq = get_spectral_equivalency(spectral_axis.doppler_rest, spectral_axis.doppler_convention)
             # Make `vel` a `SpectralCoord`.
             vel_sp = spectral_axis.to(unit=vel.unit).replicate(value=vel.value, unit=vel.unit)
             with u.set_enabled_equivalencies(eq):
@@ -958,14 +957,19 @@ class Spectrum(Spectrum1D):
         # Assumes that the WCS is in frequency.
         if isinstance(item, slice):
             if item.step is not None and item.step != 1:
-                raise NotImplementedError("Cannot slice with a step other than 1. Try smoothing and decimating if you want to downsample.")
+                raise NotImplementedError(
+                    "Cannot slice with a step other than 1. Try smoothing and decimating if you want to downsample."
+                )
 
             spectral_axis = self.spectral_axis
             # Use the WCS to convert from world to pixel values.
             wcs = self.wcs
             # We need a sky location to convert incorporating velocity shifts.
-            coo = SkyCoord(wcs.wcs.crval[wcs.wcs.lng] * wcs.wcs.cunit[wcs.wcs.lng],
-                           wcs.wcs.crval[wcs.wcs.lat] * wcs.wcs.cunit[wcs.wcs.lat], frame="fk5")
+            coo = SkyCoord(
+                wcs.wcs.crval[wcs.wcs.lng] * wcs.wcs.cunit[wcs.wcs.lng],
+                wcs.wcs.crval[wcs.wcs.lat] * wcs.wcs.cunit[wcs.wcs.lat],
+                frame="fk5",
+            )
             # Same for the Stokes axis.
             sto = StokesCoord(0)
             start = item.start
@@ -976,7 +980,7 @@ class Spectrum(Spectrum1D):
                 start_idx = q2idx(start, wcs, spectral_axis, coo, sto)
             else:
                 start_idx = start
-            
+
             # Stop.
             if isinstance(stop, u.Quantity):
                 stop_idx = q2idx(stop, wcs, spectral_axis, coo, sto)
@@ -985,10 +989,9 @@ class Spectrum(Spectrum1D):
 
         else:
             raise NotImplementedError("Use a slice for slicing.")
-            
 
         # Slicing uses NumPY ordering by default.
-        sliced_wcs = wcs[0:1,0:1,0:1,start_idx:stop_idx]
+        sliced_wcs = wcs[0:1, 0:1, 0:1, start_idx:stop_idx]
 
         # Update meta.
         meta = self.meta.copy()
@@ -997,7 +1000,9 @@ class Spectrum(Spectrum1D):
             meta[k] = head[k]
 
         # New Spectrum.
-        return self.make_spectrum(self.flux[start_idx:stop_idx], meta=meta, observer_location=Observatory[meta["TELESCOP"]])
+        return self.make_spectrum(
+            self.flux[start_idx:stop_idx], meta=meta, observer_location=Observatory[meta["TELESCOP"]]
+        )
 
 
 # @todo figure how how to document write()

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -17,7 +17,6 @@ from astropy.nddata.ccddata import fits_ccddata_writer
 from astropy.table import Table
 from astropy.time import Time
 from astropy.wcs import WCS, FITSFixedWarning
-from astropy.wcs.wcsapi import SlicedLowLevelWCS
 from ndcube import NDCube
 from specutils import Spectrum1D
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -170,25 +170,64 @@ class TestSpectrum:
         # @todo remove the temporary files.  This should be done in a teardown() method
 
     @patch("dysh.plot.specplot.plt.show")
-    def test_slice(self, mock_show):
+    def test_slice(self, mock_show, tmp_path):
         """
         Test that we can slice a `Spectrum` using channels or units.
         For units we only consider frequencies for now.
         """
+        meta_ignore = ["CRPIX1", "CRVAL1"]
+        spec_pars = ["_target", "_velocity_frame", "_observer", "_obstime", "_observer_location"]
         s = slice(1000, 1100, 1)
 
         trimmed = self.ps0[s]
         assert trimmed.flux[0] == self.ps0.flux[s.start]
         assert trimmed.flux[-1] == self.ps0.flux[s.stop - 1]
         assert np.all(trimmed.flux == self.ps0.flux[s])
-        assert np.all(trimmed.spectral_axis == self.ps0.spectral_axis[s])
+        # The slicing changes the values at the micro Hz level.
+        assert np.all(trimmed.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
         # Check meta values. The trimmed spectrum has an additional
         # key: 'original_wcs'.
         for k, v in self.ps0.meta.items():
-            assert trimmed.meta[k] == v
+            if k not in meta_ignore:
+                assert trimmed.meta[k] == v
         # Check additional object properties.
         # Not all of them make sense, since their shapes will be different.
-        for k in ["_target", "_velocity_frame", "_observer", "_obstime", "_observer_location"]:
+        for k in spec_pars:
             assert vars(trimmed)[k] == vars(self.ps0)[k]
         # Check that we can plot.
         trimmed.plot(xaxis_unit="km/s", yaxis_unit="mK")
+        # Check that we can write.
+        o = tmp_path / "sub"
+        o.mkdir()
+        out = o / "test_spec_slice_write.fits"
+        trimmed.write(out, format="fits", overwrite=True)
+        # Check that we can read it back.
+        trimmed_read = Spectrum.read(out, format="fits")
+        assert np.all(trimmed.flux == trimmed_read.flux)
+        assert np.all(trimmed.spectral_axis == trimmed_read.spectral_axis)
+        assert trimmed.target == trimmed_read.target
+
+        # Now slice using units.
+		# Hz.
+        spec_ax = self.ps0.spectral_axis
+        trimmed_nu = self.ps0[spec_ax[s.start].to("Hz"):spec_ax[s.stop].to("Hz")]
+        assert np.all(trimmed_nu.flux == self.ps0.flux[s])
+        assert np.all(trimmed_nu.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
+        for k, v in self.ps0.meta.items():
+            if k not in meta_ignore:
+                assert trimmed_nu.meta[k] == v
+        for k in spec_pars:
+            assert vars(trimmed_nu)[k] == vars(self.ps0)[k]
+        trimmed_nu.plot(xaxis_unit="km/s", yaxis_unit="mK")
+
+		# km/s.
+        spec_ax = self.ps0.spectral_axis.to("km/s")
+        trimmed_vel = self.ps0[spec_ax[s.start]:spec_ax[s.stop]]
+        assert np.all(trimmed_vel.flux == self.ps0.flux[s])
+        assert np.all(trimmed_vel.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
+        for k, v in self.ps0.meta.items():
+            if k not in meta_ignore:
+                assert trimmed_vel.meta[k] == v
+        for k in spec_pars:
+            assert vars(trimmed_vel)[k] == vars(self.ps0)[k]
+        trimmed_vel.plot(xaxis_unit="MHz", yaxis_unit="mK")

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -231,3 +231,9 @@ class TestSpectrum:
         for k in spec_pars:
             assert vars(trimmed_vel)[k] == vars(self.ps0)[k]
         trimmed_vel.plot(xaxis_unit="MHz", yaxis_unit="mK")
+
+        # m.
+        spec_ax = self.ps0.spectral_axis.to("m")
+        trimmed_wav = self.ps0[spec_ax[s.start] : spec_ax[s.stop]]
+        assert np.all(trimmed_wav.flux == self.ps0.flux[s])
+        assert np.all(trimmed_wav.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -166,3 +166,26 @@ class TestSpectrum:
         assert s2.flux[0].value == -0.1042543
         assert s2.spectral_axis.unit == u.Unit("km/s")
         # @todo remove the temporary files.  This should be done in a teardown() method
+
+    def test_slice(self):
+        """
+        Test that we can slice a `Spectrum` using channels or units.
+        For units we only consider frequencies for now.
+        """
+        s = slice(1000, 1100, 1)
+
+        trimmed = self.ps0[s]
+        assert trimmed.flux[0] == self.ps0.flux[s.start]
+        assert trimmed.flux[-1] == self.ps0.flux[s.stop - 1]
+        assert np.all(trimmed.flux == self.ps0.flux[s])
+        assert np.all(trimmed.spectral_axis == self.ps0.spectral_axis[s])
+        # Check meta values. The trimmed spectrum has an additional
+        # key: 'original_wcs'.
+        for k, v in self.ps0.meta.items():
+            assert trimmed.meta[k] == v
+        # Check additional object properties.
+        # Not all of them make sense, since their shapes will be different.
+        for k in ["_target", "_velocity_frame", "_observer", "_obstime", "_observer_location"]:
+            assert vars(trimmed)[k] == vars(self.ps0)[k]
+        # Check that we can plot.
+        trimmed.plot(xaxis_unit="km/s", yaxis_unit="mK")

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -208,9 +208,9 @@ class TestSpectrum:
         assert trimmed.target == trimmed_read.target
 
         # Now slice using units.
-		# Hz.
+        # Hz.
         spec_ax = self.ps0.spectral_axis
-        trimmed_nu = self.ps0[spec_ax[s.start].to("Hz"):spec_ax[s.stop].to("Hz")]
+        trimmed_nu = self.ps0[spec_ax[s.start].to("Hz") : spec_ax[s.stop].to("Hz")]
         assert np.all(trimmed_nu.flux == self.ps0.flux[s])
         assert np.all(trimmed_nu.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
         for k, v in self.ps0.meta.items():
@@ -220,9 +220,9 @@ class TestSpectrum:
             assert vars(trimmed_nu)[k] == vars(self.ps0)[k]
         trimmed_nu.plot(xaxis_unit="km/s", yaxis_unit="mK")
 
-		# km/s.
+        # km/s.
         spec_ax = self.ps0.spectral_axis.to("km/s")
-        trimmed_vel = self.ps0[spec_ax[s.start]:spec_ax[s.stop]]
+        trimmed_vel = self.ps0[spec_ax[s.start] : spec_ax[s.stop]]
         assert np.all(trimmed_vel.flux == self.ps0.flux[s])
         assert np.all(trimmed_vel.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
         for k, v in self.ps0.meta.items():

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1,5 +1,5 @@
-
 from unittest.mock import patch
+
 import astropy.units as u
 import numpy as np
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1,3 +1,5 @@
+
+from unittest.mock import patch
 import astropy.units as u
 import numpy as np
 
@@ -167,7 +169,8 @@ class TestSpectrum:
         assert s2.spectral_axis.unit == u.Unit("km/s")
         # @todo remove the temporary files.  This should be done in a teardown() method
 
-    def test_slice(self):
+    @patch("dysh.plot.specplot.plt.show")
+    def test_slice(self, mock_show):
         """
         Test that we can slice a `Spectrum` using channels or units.
         For units we only consider frequencies for now.


### PR DESCRIPTION
This fix forces the use of a spectral WCS object when creating a Spectrum, thus removing the error where Spectrum1D did not know how to handle celestial WCS coordinates. This also removes the STOKES axis from the WCS.

This would help fix #258 and #248 -- only in channel space. To make this work with velocity units we could add a unit conversion between frequency and velocity if needed (e.g., the user slices using velocity units on a `Spectrum` with `spectral_axis` in frequency units.

The unit tests showed no issues, but that may not be complete.

In draft status to see if the implementation makes sense to the development team.