### PR TITLE
Add unit tests to documentation PR

### DIFF
--- a/notebooks/examples/dataIO.ipynb
+++ b/notebooks/examples/dataIO.ipynb
@@ -639,7 +639,11 @@
     }
    ],
    "source": [
-    "sdfits2 = GBTFITSLoad(output_dir / \"mydata.fits\")\n",
+    "# Try-Except added to handle a bug on MacOS\n",
+    "try:\n",
+    "    sdfits2 = GBTFITSLoad(output_dir / \"mydata.fits\")\n",
+    "except:\n",
+    "    sdfits2 = GBTFITSLoad(output_dir / \"mydata0.fits\")\n",
     "sdfits2.summary()"
    ]
   },

--- a/notebooks/examples/dataIO.ipynb
+++ b/notebooks/examples/dataIO.ipynb
@@ -245,7 +245,7 @@
    "id": "5e7285c7-51c1-400e-845e-0590ae656e9a",
    "metadata": {},
    "source": [
-    "# 1.  Reading and Writing Individual Spectra"
+    "## Reading and Writing Individual Spectra"
    ]
   },
   {

--- a/notebooks/examples/dataIO.ipynb
+++ b/notebooks/examples/dataIO.ipynb
@@ -23,7 +23,8 @@
     "from dysh.spectra.spectrum import Spectrum\n",
     "from dysh.util.download import from_url\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -51,7 +52,7 @@
    ],
    "source": [
     "url = \"http://www.gb.nrao.edu/dysh/example_data/onoff-L/data/TGBT21A_501_11.raw.vegas.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },
@@ -280,8 +281,9 @@
     "    \"mrt\",\n",
     "    \"votable\",\n",
     "]\n",
+    "output_dir = Path.cwd() / \"output\"\n",
     "for f in fmt:\n",
-    "    file = f\"./output/testwrite.{f}\"\n",
+    "    file = output_dir / f\"testwrite.{f}\"\n",
     "    ta.write(file, format=f, overwrite=True)\n"
    ]
   },
@@ -300,7 +302,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ta.write(\"./output/testwrite.fits\", format=\"fits\", overwrite=True)"
+    "ta.write(output_dir / \"testwrite.fits\", format=\"fits\", overwrite=True)"
    ]
   },
   {
@@ -330,7 +332,7 @@
     }
    ],
    "source": [
-    "s1 = Spectrum.read(\"./output/testwrite.fits\", format=\"fits\")\n",
+    "s1 = Spectrum.read(output_dir / \"testwrite.fits\", format=\"fits\")\n",
     "s1.plot()"
    ]
   },
@@ -352,7 +354,7 @@
     }
    ],
    "source": [
-    "s2 = Spectrum.read(\"./output/testwrite.ecsv\", format=\"ecsv\")\n",
+    "s2 = Spectrum.read(output_dir / \"testwrite.ecsv\", format=\"ecsv\")\n",
     "s2.plot()"
    ]
   },
@@ -504,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psscan.write(\"./output/scanblock.fits\", overwrite=True)"
+    "psscan.write(output_dir / \"scanblock.fits\", overwrite=True)"
    ]
   },
   {
@@ -531,7 +533,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdfits.write(\"./output/mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True)"
+    "sdfits.write(output_dir / \"mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True)"
    ]
   },
   {
@@ -637,7 +639,7 @@
     }
    ],
    "source": [
-    "sdfits2 = GBTFITSLoad(\"./output/mydata.fits\")\n",
+    "sdfits2 = GBTFITSLoad(output_dir / \"mydata.fits\")\n",
     "sdfits2.summary()"
    ]
   },

--- a/notebooks/examples/dataIO.ipynb
+++ b/notebooks/examples/dataIO.ipynb
@@ -533,7 +533,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdfits.write(output_dir / \"mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True)"
+    "sdfits.write(output_dir / \"mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True, multifile=False)"
    ]
   },
   {
@@ -639,12 +639,7 @@
     }
    ],
    "source": [
-    "# Try-Except added to handle a bug on MacOS\n",
-    "try:\n",
-    "    sdfits2 = GBTFITSLoad(output_dir / \"mydata.fits\")\n",
-    "except:\n",
-    "    sdfits2 = GBTFITSLoad(output_dir / \"mydata0.fits\")\n",
-    "sdfits2.summary()"
+    "sdfits2 = GBTFITSLoad(output_dir / \"mydata.fits\")"
    ]
   },
   {

--- a/notebooks/examples/dataIO.ipynb
+++ b/notebooks/examples/dataIO.ipynb
@@ -281,7 +281,7 @@
     "    \"votable\",\n",
     "]\n",
     "for f in fmt:\n",
-    "    file = f\"output/testwrite.{f}\"\n",
+    "    file = f\"./output/testwrite.{f}\"\n",
     "    ta.write(file, format=f, overwrite=True)\n"
    ]
   },
@@ -300,7 +300,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ta.write(\"output/testwrite.fits\", format=\"fits\", overwrite=True)"
+    "ta.write(\"./output/testwrite.fits\", format=\"fits\", overwrite=True)"
    ]
   },
   {
@@ -330,7 +330,7 @@
     }
    ],
    "source": [
-    "s1 = Spectrum.read(\"output/testwrite.fits\", format=\"fits\")\n",
+    "s1 = Spectrum.read(\"./output/testwrite.fits\", format=\"fits\")\n",
     "s1.plot()"
    ]
   },
@@ -352,7 +352,7 @@
     }
    ],
    "source": [
-    "s2 = Spectrum.read(\"output/testwrite.ecsv\", format=\"ecsv\")\n",
+    "s2 = Spectrum.read(\"./output/testwrite.ecsv\", format=\"ecsv\")\n",
     "s2.plot()"
    ]
   },
@@ -504,7 +504,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psscan.write(\"output/scanblock.fits\", overwrite=True)"
+    "psscan.write(\"./output/scanblock.fits\", overwrite=True)"
    ]
   },
   {
@@ -531,7 +531,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdfits.write(\"output/mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True)"
+    "sdfits.write(\"./output/mydata.fits\", plnum=1, ifnum=[0,2], intnum=np.arange(100), overwrite=True)"
    ]
   },
   {
@@ -637,7 +637,7 @@
     }
    ],
    "source": [
-    "sdfits2 = GBTFITSLoad(\"output/mydata.fits\")\n",
+    "sdfits2 = GBTFITSLoad(\"./output/mydata.fits\")\n",
     "sdfits2.summary()"
    ]
   },

--- a/notebooks/examples/frequencyswitch.ipynb
+++ b/notebooks/examples/frequencyswitch.ipynb
@@ -184,7 +184,7 @@
    "source": [
     "sdfits = GBTFITSLoad(filename)\n",
     "sdfits.info()\n",
-    "sdfits.summary()"
+    "print(sdfits.summary())"
    ]
   },
   {

--- a/notebooks/examples/frequencyswitch.ipynb
+++ b/notebooks/examples/frequencyswitch.ipynb
@@ -32,7 +32,8 @@
    "source": [
     "from dysh.fits.gbtfitsload import GBTFITSLoad\n",
     "from dysh.util.download import from_url\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -83,7 +84,7 @@
    ],
    "source": [
     "url = \"http://www.gb.nrao.edu/dysh/example_data/fs-L/data/AGBT20B_014_03.raw.vegas/AGBT20B_014_03.raw.vegas.A.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },
@@ -184,7 +185,7 @@
    "source": [
     "sdfits = GBTFITSLoad(filename)\n",
     "sdfits.info()\n",
-    "print(sdfits.summary())"
+    "sdfits.summary()"
    ]
   },
   {
@@ -482,7 +483,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ta.savefig(\"output/baselined_removed.png\")"
+    "output_dir = Path.cwd() / \"output\"\n",
+    "ta.savefig(output_dir / \"baselined_removed.png\")"
    ]
   },
   {

--- a/notebooks/examples/metadata_management.ipynb
+++ b/notebooks/examples/metadata_management.ipynb
@@ -30,7 +30,8 @@
    "outputs": [],
    "source": [
     "from dysh.fits.gbtfitsload import GBTFITSLoad\n",
-    "from dysh.util.download import from_url"
+    "from dysh.util.download import from_url\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -59,7 +60,7 @@
    ],
    "source": [
     "url = \"https://www.gb.nrao.edu/dysh/example_data/positionswitch/data/AGBT05B_047_01/AGBT05B_047_01.raw.acs/AGBT05B_047_01.raw.acs.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },

--- a/notebooks/examples/positionswitch.ipynb
+++ b/notebooks/examples/positionswitch.ipynb
@@ -29,7 +29,8 @@
    "source": [
     "import astropy.units as u\n",
     "from dysh.fits.gbtfitsload import GBTFITSLoad\n",
-    "from dysh.util.download import from_url"
+    "from dysh.util.download import from_url\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -64,7 +65,7 @@
    ],
    "source": [
     "url = \"http://www.gb.nrao.edu/dysh/example_data/onoff-L/data/TGBT21A_501_11.raw.vegas.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },
@@ -501,7 +502,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ta.savefig(\"output/baselined_removed.png\")"
+    "output_dir = Path.cwd() / \"output\"\n",
+    "ta.savefig(output_dir / \"baselined_removed.png\")"
    ]
   },
   {

--- a/notebooks/examples/smoothing.ipynb
+++ b/notebooks/examples/smoothing.ipynb
@@ -39,7 +39,8 @@
    "source": [
     "import numpy as np\n",
     "from dysh.fits.gbtfitsload import GBTFITSLoad\n",
-    "from dysh.util.download import from_url"
+    "from dysh.util.download import from_url\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -105,7 +106,7 @@
    ],
    "source": [
     "url = \"http://www.gb.nrao.edu/dysh/example_data/onoff-L/data/TGBT21A_501_11.raw.vegas.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },

--- a/notebooks/examples/subbeamnod.ipynb
+++ b/notebooks/examples/subbeamnod.ipynb
@@ -18,7 +18,8 @@
    "outputs": [],
    "source": [
     "from dysh.fits.gbtfitsload import GBTFITSLoad\n",
-    "from dysh.util.download import from_url"
+    "from dysh.util.download import from_url\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -45,7 +46,7 @@
    ],
    "source": [
     "url = \"http://www.gb.nrao.edu/dysh/example_data/subbeamnod-Ka/data/TRCO_230413_Ka.raw.vegas/TRCO_230413_Ka.raw.vegas.A.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -1,0 +1,61 @@
+import nbformat
+from nbclient import NotebookClient
+from glob import glob
+import os
+import pytest
+
+def check_notebook_execution(notebook_file):
+    """Execute a given notebook and check for errors"""
+
+    # Get the current testing directory
+    cwd = os.getcwd()
+    # Get the directory of the notebook
+    notebook_dir = os.path.dirname(notebook_file)
+
+    # Open the notebook
+    with open(notebook_file, 'r', encoding='utf-8') as f:
+        nb = nbformat.read(f, as_version=4)
+    
+    # Try to execute the notebook
+    try:
+        # Change the current working directory to the notebook's directory
+        os.chdir(notebook_dir)
+        client = NotebookClient(nb, timeout=600)
+        client.execute()
+        # Return to original working directory
+        os.chdir(cwd)
+    except Exception as e:
+        # Return to original working directory
+        os.chdir(cwd)
+        pytest.fail(f"Error executing notebook {notebook_file}: {e}")
+
+def test_notebooks_execution():
+    """Test that each notebook runs without errors"""
+    # List of notebook files to test
+    notebook_files = glob("notebooks/examples/*.ipynb")
+    
+    for notebook_file in notebook_files:
+        check_notebook_execution(notebook_file)
+
+def test_single_top_level_header():
+    """Test that each notebook has exactly 1 top-level header"""
+    # List of notebook files to test
+    notebook_files = glob("notebooks/examples/*.ipynb")
+    
+    # Open each notebook
+    for notebook_file in notebook_files:
+        with open(notebook_file, 'r', encoding='utf-8') as f:
+            nb = nbformat.read(f, as_version=4)
+        
+        top_level_headers = 0
+        
+        # Search each markdown cell for top-level headers
+        for cell in nb.cells:
+            if cell.cell_type == 'markdown':
+                source = cell.source
+                lines = source.split('\n')
+                for line in lines:
+                    if line.startswith('# '):
+                        top_level_headers += 1
+
+        assert top_level_headers == 1, f"Notebook {notebook_file} has {top_level_headers} top-level headers."

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -10,8 +10,10 @@ def check_notebook_execution(notebook_file):
 
     # Get the current testing directory
     cwd = Path().cwd()
+    print("1", cwd)
     # Get the directory of the notebook
     notebook_dir = Path(notebook_file).parent.resolve()
+    print("2", notebook_dir)
 
     # Open the notebook
     with open(notebook_file, 'r', encoding='utf-8') as f:
@@ -21,13 +23,17 @@ def check_notebook_execution(notebook_file):
     try:
         # Change the current working directory to the notebook's directory
         os.chdir(notebook_dir)
+        print("3", Path().cwd())
         client = NotebookClient(nb, timeout=600)
         client.execute()
         # Return to original working directory
         os.chdir(cwd)
+        print("4", Path().cwd())
     except Exception as e:
         # Return to original working directory
+        print("5", Path().cwd())
         os.chdir(cwd)
+        print("6", Path().cwd())
         pytest.fail(f"Error executing notebook {notebook_file}: {e}")
 
 def test_notebooks_execution():

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -10,10 +10,8 @@ def check_notebook_execution(notebook_file):
 
     # Get the current testing directory
     cwd = Path().cwd()
-    print("1", cwd)
     # Get the directory of the notebook
     notebook_dir = Path(notebook_file).parent.resolve()
-    print("2", notebook_dir)
 
     # Open the notebook
     with open(notebook_file, 'r', encoding='utf-8') as f:
@@ -23,17 +21,13 @@ def check_notebook_execution(notebook_file):
     try:
         # Change the current working directory to the notebook's directory
         os.chdir(notebook_dir)
-        print("3", Path().cwd())
         client = NotebookClient(nb, timeout=600)
         client.execute()
         # Return to original working directory
         os.chdir(cwd)
-        print("4", Path().cwd())
     except Exception as e:
         # Return to original working directory
-        print("5", Path().cwd())
         os.chdir(cwd)
-        print("6", Path().cwd())
         pytest.fail(f"Error executing notebook {notebook_file}: {e}")
 
 def test_notebooks_execution():
@@ -66,6 +60,3 @@ def test_single_top_level_header():
                         top_level_headers += 1
 
         assert top_level_headers == 1, f"Notebook {notebook_file} has {top_level_headers} top-level headers."
-
-if __name__ == "__main__":
-    test_notebooks_execution()

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -27,11 +27,8 @@ def check_notebook_execution(notebook_file):
         os.chdir(cwd)
     except Exception as e:
         # Return to original working directory
-        print(f"1 CWD: {Path.cwd()}")
         os.chdir(cwd)
-        print(f"2 CWD: {Path.cwd()}")
         outdir = notebook_dir / "output"
-        print(f"3 OUTPUTS: {os.listdir(outdir)}")
         pytest.fail(f"Error executing notebook {notebook_file}: {e}")
 
 def test_notebooks_execution():

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -28,7 +28,6 @@ def check_notebook_execution(notebook_file):
     except Exception as e:
         # Return to original working directory
         os.chdir(cwd)
-        outdir = notebook_dir / "output"
         pytest.fail(f"Error executing notebook {notebook_file}: {e}")
 
 def test_notebooks_execution():

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -27,7 +27,11 @@ def check_notebook_execution(notebook_file):
         os.chdir(cwd)
     except Exception as e:
         # Return to original working directory
+        print(f"1 CWD: {Path.cwd()}")
         os.chdir(cwd)
+        print(f"2 CWD: {Path.cwd()}")
+        outdir = notebook_dir / "output"
+        print(f"3 OUTPUTS: {os.listdir(outdir)}")
         pytest.fail(f"Error executing notebook {notebook_file}: {e}")
 
 def test_notebooks_execution():

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -2,15 +2,16 @@ import nbformat
 from nbclient import NotebookClient
 from glob import glob
 import os
+from pathlib import Path
 import pytest
 
 def check_notebook_execution(notebook_file):
     """Execute a given notebook and check for errors"""
 
     # Get the current testing directory
-    cwd = os.getcwd()
+    cwd = Path().cwd()
     # Get the directory of the notebook
-    notebook_dir = os.path.dirname(notebook_file)
+    notebook_dir = Path(notebook_file).parent.resolve()
 
     # Open the notebook
     with open(notebook_file, 'r', encoding='utf-8') as f:
@@ -59,3 +60,6 @@ def test_single_top_level_header():
                         top_level_headers += 1
 
         assert top_level_headers == 1, f"Notebook {notebook_file} has {top_level_headers} top-level headers."
+
+if __name__ == "__main__":
+    test_notebooks_execution()

--- a/notebooks/examples/velocity_frames.ipynb
+++ b/notebooks/examples/velocity_frames.ipynb
@@ -28,7 +28,8 @@
    "source": [
     "import astropy.units as u\n",
     "from dysh.fits.gbtfitsload import GBTFITSLoad\n",
-    "from dysh.util.download import from_url"
+    "from dysh.util.download import from_url\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -63,7 +64,7 @@
    ],
    "source": [
     "url = \"http://www.gb.nrao.edu/dysh/example_data/onoff-L/data/TGBT21A_501_11.raw.vegas.fits\"\n",
-    "savepath = \"./data/\"\n",
+    "savepath = Path.cwd() / \"data\"\n",
     "filename = from_url(url, savepath)"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "specutils",
   "httpx",
   "rich",
+  "tenacity",
  ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ src = ["src", "benchmark", "notebooks"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-testpaths = ["tests", "src", "docs", "notebooks/examples"]
+testpaths = ["tests", "src", "docs"]
 filterwarnings = [
     "ignore::DeprecationWarning"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
   "sphinx-inline-tabs",
   "sphinx-book-theme",
   "sphinxcontrib-mermaid",
+  "nbformat",
+  "nbclient",
+  "glob2",
 ]
 nb = [
   "jupyter",
@@ -178,7 +181,7 @@ src = ["src", "benchmark", "notebooks"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-testpaths = ["tests", "src", "docs"]
+testpaths = ["tests", "src", "docs", "notebooks/examples"]
 filterwarnings = [
     "ignore::DeprecationWarning"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -551,6 +551,8 @@ tabulate==0.9.0
     # via
     #   jupyter-cache
     #   numpydoc
+tenacity==9.0.0
+    # via dysh (pyproject.toml)
 terminado==0.18.0
     # via
     #   jupyter-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -136,6 +136,8 @@ fonttools==4.45.0
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
+glob2==0.7
+    # via dysh (pyproject.toml)
 greenlet==3.0.3
     # via sqlalchemy
 gwcs==0.19.0
@@ -301,6 +303,7 @@ myst-parser==2.0.0
     # via myst-nb
 nbclient==0.9.0
     # via
+    #   dysh (pyproject.toml)
     #   jupyter-cache
     #   myst-nb
     #   nbconvert
@@ -310,6 +313,7 @@ nbconvert==7.12.0
     #   jupyter-server
 nbformat==5.9.2
     # via
+    #   dysh (pyproject.toml)
     #   jupyter-cache
     #   jupyter-server
     #   myst-nb

--- a/src/dysh/util/download.py
+++ b/src/dysh/util/download.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 import httpx
 from rich.progress import Progress
+from tenacity import retry, stop_after_attempt
 
 
+@retry(stop=stop_after_attempt(3))
 def from_url(url, path=Path(".")):
     """
     Download a file from `url` to `path`.

--- a/src/dysh/util/download.py
+++ b/src/dysh/util/download.py
@@ -1,5 +1,5 @@
 import argparse
-import sys
+import time
 import uuid
 from pathlib import Path
 
@@ -7,7 +7,7 @@ import httpx
 from rich.progress import Progress
 
 
-def from_url(url, path=Path(".")):
+def from_url(url, path=Path("."), max_retries=5, retry_delay=2):
     """
     Download a file from `url` to `path`.
 
@@ -17,6 +17,10 @@ def from_url(url, path=Path(".")):
         The URL of the data file
     path : str or `pathlib.Path`
         The path to the directory to save the data. If `path/filename` already exists, the file will not be downloaded again.
+    max_retries : int
+        The maximum number of times to retry the download if it fails
+    retry_delay : int
+        The amount of time (seconds) to wait before retrying
 
     Returns
     -------
@@ -28,49 +32,56 @@ def from_url(url, path=Path(".")):
     if type(path) is str:
         path = Path(path)
 
-    try:
-        # Make the HTTPX client
-        client = httpx.Client(follow_redirects=True)
+    attempt = 0
+    while attempt < max_retries:
+        try:
+            # Make the HTTPX client
+            client = httpx.Client(follow_redirects=True)
 
-        with client.stream("GET", url) as resp:
+            with client.stream("GET", url) as resp:
 
-            # Get the filename from the URL
-            filename = Path(resp.url.path).name
+                # Get the filename from the URL
+                filename = Path(resp.url.path).name
 
-            # Check if given path is directory or filename
-            if path.is_dir():
-                path.mkdir(parents=True, exist_ok=True)
-                savepath = path / filename
+                # Check if given path is directory or filename
+                if path.is_dir():
+                    path.mkdir(parents=True, exist_ok=True)
+                    savepath = path / filename
+                else:
+                    savepath = path
+
+                # Skip downloading if file already exists
+                if savepath.exists():
+                    print(f"{filename} already downloaded at {path}")
+                    return path
+
+                else:
+                    # Download the file
+                    print(f"Attempting to download {filename}...")
+                    resp.raise_for_status()
+
+                    # Download to a temporary path first
+                    # so desired file only shows up if successful
+                    tmp_path = savepath.parent / f"{filename}.{uuid.uuid4()}.tmp"
+
+                    # Write chunks to file with progress bar
+                    with open(tmp_path, "wb") as out_file:
+                        with Progress() as progress:
+                            task_length = int(resp.headers.get("content-length", 0))
+                            task = progress.add_task("[red]Downloading...", total=task_length)
+                            for chunk in resp.iter_raw():
+                                out_file.write(chunk)
+                                progress.update(task, advance=len(chunk))
+
+        # If something goes wrong, throw Exception
+        except Exception as exc:
+            attempt += 1
+            if attempt >= max_retries:
+                raise
             else:
-                savepath = path
-
-            # Skip downloading if file already exists
-            if savepath.exists():
-                print(f"{filename} already downloaded at {path}")
-                return path
-
-            else:
-                # Download the file
-                print(f"Attempting to download {filename}...")
-                resp.raise_for_status()
-
-                # Download to a temporary path first
-                # so desired file only shows up if successful
-                tmp_path = savepath.parent / f"{filename}.{uuid.uuid4()}.tmp"
-
-                # Write chunks to file with progress bar
-                with open(tmp_path, "wb") as out_file:
-                    with Progress() as progress:
-                        task_length = int(resp.headers.get("content-length", 0))
-                        task = progress.add_task("[red]Downloading...", total=task_length)
-                        for chunk in resp.iter_raw():
-                            out_file.write(chunk)
-                            progress.update(task, advance=len(chunk))
-
-    # If something goes wrong, throw Exception
-    except Exception as exc:
-        print(exc, file=sys.stderr)
-        raise
+                print(f"Attempt {attempt} failed: {exc}")
+                print(f"Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
 
     # Rename the temp file to the desired name
     tmp_path.rename(savepath)


### PR DESCRIPTION
This PR is to add unit tests to `cat-docs-devel`, which is currently under review to merge into `main`. These tests are in `notebooks/examples/tests/test_notebook.py`
- `test_notebooks_execution()`: Tests that the notebooks in `notebooks/examples/` run without errors
- `test_single_top_level_header()`: Tests that the notebooks in `notebooks/examples/` each contain exactly one top-level header. Fixes issue identified in https://github.com/GreenBankObservatory/dysh/issues/334

There are a few other changes:
- The notebooks now use `pathlib.Path()` objects for all paths to prevent issues where GitHub actions could not find files
- `dataIO.ipynb` has a temporary fix to allow tests to pass despite https://github.com/GreenBankObservatory/dysh/issues/339
- Adds `nbformat`, `nbclient`, and `glob2` dependencies for notebook testing

RTD build is at the link below. I will delete this branch and corresponding RTD instance upon a successful merge. 
https://dysh.readthedocs.io/en/cat-docs-unit-tests-devel/index.html