### PR TITLE
307 wcs wrong after a smoothed spectrum is indexed ps review

### DIFF
--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -374,10 +374,9 @@ class Spectrum(Spectrum1D):
         new_data = self.data[idx] * self.flux.unit
         new_meta["CDELT1"] = new_cdelt1
         new_meta["CRPIX1"] = 1.0 + (self.meta["CRPIX1"] - 1) / n + 0.5 * (n - 1) / n
+        new_meta["CRVAL1"] += cell_shift
 
         s = Spectrum.make_spectrum(new_data, meta=new_meta)
-        # Apply cell shift.
-        s._spectral_axis = self.spectral_axis.replicate(value=s._spectral_axis + cell_shift * s.spectral_axis.unit)
 
         if self._baseline_model is not None:
             s._baseline_model = self._baseline_model[idx]


### PR DESCRIPTION
In this PR:
* Refactor the code for `Spectrum.smooth`. Not it is split into smoothing and decimation. This also adds a `Spectrum.decimate` method.
* Updates the WCS of a `Spectrum` after smoothing/decimating.
* Updates the value of `Spectrum._resolution`.
* Adds tests for `Spectrum.smooth`.