### PR TITLE
Q7 spectrum align return copy

### DIFF
--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -542,26 +542,23 @@ class Spectrum(Spectrum1D, HistoricalBase):
             "fft" uses a phase shift.
         """
 
-        new_spec = self._copy()
         new_data = core.data_shift(self.data, s, remove_wrap=remove_wrap, fill_value=fill_value, method=method)
 
         # Update data values.
-        new_spec._data = new_data
+        self._data = new_data
 
         # Update metadata.
-        new_spec.meta["CRPIX1"] += s
+        self.meta["CRPIX1"] += s
 
         # Update WCS.
-        new_spec.wcs.wcs.crpix[0] += s
+        self.wcs.wcs.crpix[0] += s
 
         # Update `SpectralAxis` values.
         # Radial velocity needs to be copied by hand.
-        radial_velocity = deepcopy(new_spec._spectral_axis._radial_velocity)
-        new_spectral_axis_values = new_spec.wcs.spectral.pixel_to_world(np.arange(new_spec.flux.shape[-1]))
-        new_spec._spectral_axis = new_spec.spectral_axis.replicate(value=new_spectral_axis_values)
-        new_spec._spectral_axis._radial_velocity = radial_velocity
-
-        return new_spec
+        radial_velocity = deepcopy(self._spectral_axis._radial_velocity)
+        new_spectral_axis_values = self.wcs.spectral.pixel_to_world(np.arange(self.flux.shape[-1]))
+        self._spectral_axis = self.spectral_axis.replicate(value=new_spectral_axis_values)
+        self._spectral_axis._radial_velocity = radial_velocity
 
     def find_shift(self, other, units=None, frame=None):
         """
@@ -636,7 +633,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         """
 
         s = self.find_shift(other, units=units, frame=frame)
-        return self.shift(s, remove_wrap=remove_wrap, fill_value=fill_value, method=method)
+        self.shift(s, remove_wrap=remove_wrap, fill_value=fill_value, method=method)
 
     @property
     def equivalencies(self):
@@ -1557,9 +1554,12 @@ def average_spectra(spectra, equal_weights=False, align=False):
                 f"Element {i} of `spectra` has units {s.flux.unit}, but the first element has units {units}."
             )
         if align:
+            s_ = s._copy()
             if i > 0:
-                s = s.align_to(spectra[0])
-        data_array[i] = s.data
+                s_.align_to(spectra[0])
+        else:
+            s_ = s
+        data_array[i] = s_.data
         if not equal_weights:
             weights[i] = core.tsys_weight(s.meta["EXPOSURE"], s.meta["CDELT1"], s.meta["TSYS"])
         else:

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -542,23 +542,26 @@ class Spectrum(Spectrum1D, HistoricalBase):
             "fft" uses a phase shift.
         """
 
+        new_spec = self._copy()
         new_data = core.data_shift(self.data, s, remove_wrap=remove_wrap, fill_value=fill_value, method=method)
 
         # Update data values.
-        self._data = new_data
+        new_spec._data = new_data
 
         # Update metadata.
-        self.meta["CRPIX1"] += s
+        new_spec.meta["CRPIX1"] += s
 
         # Update WCS.
-        self.wcs.wcs.crpix[0] += s
+        new_spec.wcs.wcs.crpix[0] += s
 
         # Update `SpectralAxis` values.
         # Radial velocity needs to be copied by hand.
-        radial_velocity = deepcopy(self._spectral_axis._radial_velocity)
-        new_spectral_axis_values = self.wcs.spectral.pixel_to_world(np.arange(self.flux.shape[-1]))
-        self._spectral_axis = self.spectral_axis.replicate(value=new_spectral_axis_values)
-        self._spectral_axis._radial_velocity = radial_velocity
+        radial_velocity = deepcopy(new_spec._spectral_axis._radial_velocity)
+        new_spectral_axis_values = new_spec.wcs.spectral.pixel_to_world(np.arange(new_spec.flux.shape[-1]))
+        new_spec._spectral_axis = new_spec.spectral_axis.replicate(value=new_spectral_axis_values)
+        new_spec._spectral_axis._radial_velocity = radial_velocity
+
+        return new_spec
 
     def find_shift(self, other, units=None, frame=None):
         """
@@ -633,7 +636,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         """
 
         s = self.find_shift(other, units=units, frame=frame)
-        self.shift(s, remove_wrap=remove_wrap, fill_value=fill_value, method=method)
+        return self.shift(s, remove_wrap=remove_wrap, fill_value=fill_value, method=method)
 
     @property
     def equivalencies(self):
@@ -1554,12 +1557,9 @@ def average_spectra(spectra, equal_weights=False, align=False):
                 f"Element {i} of `spectra` has units {s.flux.unit}, but the first element has units {units}."
             )
         if align:
-            s_ = s._copy()
             if i > 0:
-                s_.align_to(spectra[0])
-        else:
-            s_ = s
-        data_array[i] = s_.data
+                s = s.align_to(spectra[0])
+        data_array[i] = s.data
         if not equal_weights:
             weights[i] = core.tsys_weight(s.meta["EXPOSURE"], s.meta["CDELT1"], s.meta["TSYS"])
         else:

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -412,7 +412,7 @@ class TestSpectrum:
 
         # Apply method to be tested.
         shift = 5.5
-        spec.shift(shift)
+        spec = spec.shift(shift)
 
         # Internal tests.
         assert np.all(np.isnan(spec[: int(np.round(shift))].data))
@@ -480,20 +480,20 @@ class TestSpectrum:
         org_spec = spec._copy()
 
         # Align to itself.
-        spec.align_to(spec)
+        spec = spec.align_to(spec)
         compare_spectrum(spec, org_spec, ignore_history=True)
         assert np.all((spec - org_spec).data == 0)
 
         # Align to a shifted version.
         shift = 5
-        spec.shift(shift)
+        spec = spec.shift(shift)
         assert np.all((spec.data[shift:] - org_spec.data[:-shift]) == 0.0)
 
         # Align to a shifted version with signal.
         fshift = 0.5
         spec = self.ss._copy()
         org_spec = spec._copy()
-        spec.shift(shift + fshift)
+        spec = spec.shift(shift + fshift)
         # The amplitude of the signal will decrease because of the sampling.
         tol = np.sqrt(
             (1 - np.exp(-0.5 * (fshift) ** 2 / spec.meta["STDD"] ** 2)) ** 2.0

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -412,7 +412,7 @@ class TestSpectrum:
 
         # Apply method to be tested.
         shift = 5.5
-        spec = spec.shift(shift)
+        spec.shift(shift)
 
         # Internal tests.
         assert np.all(np.isnan(spec[: int(np.round(shift))].data))
@@ -480,20 +480,20 @@ class TestSpectrum:
         org_spec = spec._copy()
 
         # Align to itself.
-        spec = spec.align_to(spec)
+        spec.align_to(spec)
         compare_spectrum(spec, org_spec, ignore_history=True)
         assert np.all((spec - org_spec).data == 0)
 
         # Align to a shifted version.
         shift = 5
-        spec = spec.shift(shift)
+        spec.shift(shift)
         assert np.all((spec.data[shift:] - org_spec.data[:-shift]) == 0.0)
 
         # Align to a shifted version with signal.
         fshift = 0.5
         spec = self.ss._copy()
         org_spec = spec._copy()
-        spec = spec.shift(shift + fshift)
+        spec.shift(shift + fshift)
         # The amplitude of the signal will decrease because of the sampling.
         tol = np.sqrt(
             (1 - np.exp(-0.5 * (fshift) ** 2 / spec.meta["STDD"] ** 2)) ** 2.0


### PR DESCRIPTION
This PR changes the behavior of `Spectrum.align_to` and `Spectrum.shift` to return a new `Spectrum`.