### PR TITLE
Fix: support for flag files written by GBTIDL

### DIFF
--- a/src/dysh/util/selection.py
+++ b/src/dysh/util/selection.py
@@ -1230,7 +1230,7 @@ class Flag(SelectionBase):
             else:
                 values = l.split("|")
                 for i, v in enumerate(values):
-                    if v == "*":
+                    if v.strip() == "*":
                         continue
                     else:
                         if header[i] == "IDSTRING":
@@ -1238,6 +1238,8 @@ class Flag(SelectionBase):
                         else:
                             if "," in v:
                                 vdict[header[i]] = [int(float(x)) for x in v.split(",")]
+                            elif ":" in v:
+                                vdict[header[i]] = [int(float(x)) for x in v.split(":")]
                             else:
                                 vdict[header[i]] = int(float(v))
 
@@ -1254,6 +1256,18 @@ class Flag(SelectionBase):
                     echan = [int(float(x)) for x in echan]
                     # pair up echan and bchan
                     vdict["channel"] = list(zip(bchan, echan))
+                elif bchan is not None and echan is None:
+                    if not isinstance(bchan, list):
+                        bchan = [bchan]
+                    bchan = [int(float(x)) for x in bchan]
+                    vdict["channel"] = tuple(zip(bchan))
+                elif bchan is None and echan is not None:
+                    if not isinstance(echan, list):
+                        echan = [echan]
+                    echan = [int(float(x)) for x in echan]
+                    bchan = [0] * len(echan)
+                    vdict["channel"] = tuple(zip(bchan, echan))
+
                 if kwargs is not None:
                     vdict.update(kwargs)
                 logger.debug(f"flag({tag=},{vdict})")


### PR DESCRIPTION
Minor tweaks to support flag files written/modified by GBTIDL:
* Support for ranges (e.g., 41:52)
* Support for start channel with no end channel (does not work due to issues with how the flags are handled downstream, but the channel ranges are parsed "correctly")
* Support for end channel without start channel (does not work due to issues with how the flags are handled downstream, but the channel ranges are parsed "correctly")