### PR TITLE
442 flags not getting applied to calibration routine

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -17,6 +17,7 @@ from ..spectra.scan import FSScan, NodScan, PSScan, ScanBlock, SubBeamNodScan, T
 from ..util import (
     consecutive,
     convert_array_to_mask,
+    eliminate_flagged_rows,
     indices_where_value_changes,
     keycase,
     select_from,
@@ -294,17 +295,17 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         fitsindex: int
             the index of the FITS file contained in this GBTFITSLoad.  Default:0
         setmask : boolean
-            If True, set the mask according to the current flags. Defaultf:false
+            If True, set the mask according to the current flags. Default:False
 
         Returns
         -------
         rawspectra : ~numpy.ndarray
-            The DATA column of the input bintable
+            The DATA column of the input bintable, masked according to `setmask`
 
         """
-        return self._sdf[fitsindex].rawspectra(bintable)
+        return self._sdf[fitsindex].rawspectra(bintable, setmask=setmask)
 
-    def rawspectrum(self, i, bintable=0, fitsindex=0):
+    def rawspectrum(self, i, bintable=0, fitsindex=0, setmask=False):
         """
         Get a single raw (unprocessed) spectrum from the input bintable.
 
@@ -316,14 +317,16 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             The index of the `bintable` attribute. If None, the underlying bintable is computed from i
         fitsindex: int
             the index of the FITS file contained in this GBTFITSLoad.  Default:0
+        setmask : bool
+            If True, set the data mask according to the current flags. Default:False
 
         Returns
         -------
-        rawspectrum : ~numpy.ndarray
-            The i-th row of DATA column of the input bintable
+        rawspectrum : ~numpy.ma.MaskedArray
+            The i-th row of DATA column of the input bintable, masked according to `setmask`
 
         """
-        return self._sdf[fitsindex].rawspectrum(i, bintable)
+        return self._sdf[fitsindex].rawspectrum(i, bintable, setmask=setmask)
 
     def getspec(self, i, bintable=0, observer_location=Observatory["GBT"], fitsindex=0):
         """
@@ -786,6 +789,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 rows = g["ROW"].to_numpy()
                 logger.debug(f"Applying {chan} to {rows=}")
                 logger.debug(f"{np.where(chan_mask)}")
+                # print(f"Applying {chan} to {rows=}")
+                # print(f"{np.where(chan_mask)}")
                 self._sdf[fi]._flagmask[bi][rows] |= chan_mask
 
     @log_call_to_history
@@ -996,6 +1001,11 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         # now downselect with any additional kwargs
         ps_selection._select_from_mixed_kwargs(**kwargs)
         _sf = ps_selection.final
+        # now remove rows that have been entirely flagged
+        if apply_flags:
+            _sf = eliminate_flagged_rows(_sf, self.flags.final)
+        if len(_sf) == 0:
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         logger.debug(f"SF={_sf}")
         ifnum = uniq(_sf["IFNUM"])
         plnum = uniq(_sf["PLNUM"])
@@ -1137,9 +1147,13 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         for k, v in preselected.items():
             if k not in kwargs:
                 kwargs[k] = v
+
         # now downselect with any additional kwargs
         ps_selection._select_from_mixed_kwargs(**kwargs)
         _sf = ps_selection.final
+        # now remove rows that have been entirely flagged
+        if apply_flags:
+            _sf = eliminate_flagged_rows(_sf, self.flags.final)
         logger.debug(f"{_sf = }")
         if len(_sf) == 0:
             raise Exception("Didn't find any scans matching the input selection criteria.")
@@ -1340,8 +1354,11 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         # now downselect with any additional kwargs
         ps_selection._select_from_mixed_kwargs(**kwargs)
         _sf = ps_selection.final
+        # now remove rows that have been entirely flagged
+        if apply_flags:
+            _sf = eliminate_flagged_rows(_sf, self.flags.final)
         if len(_sf) == 0:
-            raise Exception("Didn't find any scans matching the input selection criteria.")
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         elif len(_sf) < 100:
             logger.debug(f"{_sf = }")
         else:
@@ -1418,7 +1435,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                         scanblock.append(g)
                         c = c + 1
         if len(scanblock) == 0:
-            raise Exception("Didn't find any scans matching the input selection criteria.")
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         if len(scanblock) % 2 == 1:
             raise Exception("Odd number of scans for getnod, check your feeds if they are valid")
         # note the two nods are not merged, but added to the pool as two "independant" PS scans
@@ -1526,8 +1543,11 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         fs_selection._select_from_mixed_kwargs(**kwargs)
         logger.debug(fs_selection.show())
         _sf = fs_selection.final
+        # now remove rows that have been entirely flagged
+        if apply_flags:
+            _sf = eliminate_flagged_rows(_sf, self.flags.final)
         if len(_sf) == 0:
-            raise Exception("Didn't find any scans matching the input selection criteria.")
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         # _sf = fs_selection.merge(how='inner')   ## ??? PJT
         ifnum = set(_sf["IFNUM"])
         plnum = set(_sf["PLNUM"])
@@ -1577,7 +1597,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                     g.merge_commentary(self)
                     scanblock.append(g)
         if len(scanblock) == 0:
-            raise Exception("Didn't find any scans matching the input selection criteria.")
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         scanblock.merge_commentary(self)
         return scanblock
         # end of getfs()
@@ -1675,6 +1695,11 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         ps_selection = copy.deepcopy(self._selection)
         ps_selection._select_from_mixed_kwargs(**kwargs)
         _sf = ps_selection.final
+        # now remove rows that have been entirely flagged
+        if apply_flags:
+            _sf = eliminate_flagged_rows(_sf, self.flags.final)
+        if len(_sf) == 0:
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         ifnum = uniq(_sf["IFNUM"])
         plnum = uniq(_sf["PLNUM"])
         scans = uniq(_sf["SCAN"])
@@ -1848,7 +1873,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                         sb.merge_commentary(self)
                         scanblock.append(sb)
         if len(scanblock) == 0:
-            raise Exception("Didn't find any scans matching the input selection criteria.")
+            raise Exception("Didn't find any unflagged scans matching the input selection criteria.")
         scanblock.merge_commentary(self)
         return scanblock
 

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -319,7 +319,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             the index of the FITS file contained in this GBTFITSLoad.  Default:0
         setmask : bool
             If True, set the data mask according to the current flags. Default:False
-
+            Note: if :meth:`apply_flags` has not been called, flags will not yet be set.
         Returns
         -------
         rawspectrum : ~numpy.ma.MaskedArray
@@ -328,7 +328,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         """
         return self._sdf[fitsindex].rawspectrum(i, bintable, setmask=setmask)
 
-    def getspec(self, i, bintable=0, observer_location=Observatory["GBT"], fitsindex=0):
+    def getspec(self, i, bintable=0, observer_location=Observatory["GBT"], fitsindex=0, setmask=False):
         """
         Get a row (record) as a Spectrum
 
@@ -345,13 +345,16 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             the SDFITS header.  The default is the location of the GBT.
         fitsindex: int
             the index of the FITS file contained in this GBTFITSLoad.  Default:0
+        setmask : bool
+            If True, set the data mask according to the current flags. Default:False
+            Note: if :meth:`apply_flags` has not been called, flags will not yet be set.
         Returns
         -------
         s : `~dysh.spectra.spectrum.Spectrum`
             The Spectrum object representing the data row.
 
         """
-        return self._sdf[fitsindex].getspec(i, bintable, observer_location)
+        return self._sdf[fitsindex].getspec(i, bintable, observer_location, setmask=setmask)
 
     def summary(self, scans=None, verbose=False, show_index=True):  # selected=False
         # From GBTIDL:

--- a/src/dysh/fits/sdfitsload.py
+++ b/src/dysh/fits/sdfitsload.py
@@ -451,7 +451,7 @@ class SDFITSLoad(object):
         """
         return self._bintable[bintable].data[i]
 
-    def getspec(self, i, bintable=0, observer_location=None):
+    def getspec(self, i, bintable=0, observer_location=None, setmask=False):
         """
         Get a row (record) as a Spectrum
 
@@ -465,6 +465,8 @@ class SDFITSLoad(object):
             Location of the observatory. See `~dysh.coordinates.Observatory`.
             This will be transformed to `~astropy.coordinates.ITRS` using the time of observation DATE-OBS or MJD-OBS in
             the SDFITS header.  The default is None.
+        setmask : bool
+            If True, set the data mask according to the current flags in the `_flagmask` attribute.
 
         Returns
         -------
@@ -474,7 +476,7 @@ class SDFITSLoad(object):
         """
         df = self.index(bintable=bintable)
         meta = df.iloc[i].dropna().to_dict()
-        data = self.rawspectrum(i, bintable)
+        data = self.rawspectrum(i, bintable, setmask=setmask)
         meta["NAXIS1"] = len(data)
         if "CUNIT1" not in meta:
             meta["CUNIT1"] = "Hz"  # @todo this is in gbtfits.hdu[0].header['TUNIT11'] but is it always TUNIT11?

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -61,8 +61,13 @@ class TestGBTFITSLoad:
 
         sdf_file = f"{self.data_dir}/TGBT21A_501_11/TGBT21A_501_11.raw.vegas.fits"
         sdf = gbtfitsload.GBTFITSLoad(sdf_file)
-        spec = sdf.getspec(0)
-        # @todo add flag check.
+        sdf.flag_channel([[0, 100]])
+        sdf.apply_flags()
+        spec = sdf.getspec(0, setmask=False)
+        spec2 = sdf.getspec(0, setmask=True)
+        assert any(spec.mask != spec2.mask)
+        assert all(spec2.mask[0:101])
+        assert all(spec2.mask[102:] == False)
 
     def test_getps_single_int(self):
         """

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -62,6 +62,7 @@ class TestGBTFITSLoad:
         sdf_file = f"{self.data_dir}/TGBT21A_501_11/TGBT21A_501_11.raw.vegas.fits"
         sdf = gbtfitsload.GBTFITSLoad(sdf_file)
         spec = sdf.getspec(0)
+        # @todo add flag check.
 
     def test_getps_single_int(self):
         """
@@ -728,3 +729,16 @@ class TestGBTFITSLoad:
         ps = sdf.getps(scan=19, plnum=0, apply_flags=True, intnum=[i for i in range(43, 52)]).timeaverage()
         assert np.all(ps.mask[2299:] == True)
         assert np.all(ps.mask[:2299] == False)
+
+    def test_rawspectrum(self):
+        """regression test for issue 442"""
+        fits_path = util.get_project_testdata() / "AGBT05B_047_01/AGBT05B_047_01.raw.acs/AGBT05B_047_01.raw.acs.fits"
+        sdf = gbtfitsload.GBTFITSLoad(fits_path)
+        psscan = sdf.getps(plnum=0)
+        spec = psscan.timeaverage()
+        exp1 = spec.meta["EXPOSURE"]  # 214.86978780485427
+        sdf.flag_range(elevation=((None, 18.4)))
+        psscan2 = sdf.getps(plnum=0)
+        spec2 = psscan2.timeaverage()
+        exp2 = spec2.meta["EXPOSURE"]  # 58.59014643665782
+        assert exp2 < exp1

--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -995,7 +995,7 @@ class PSScan(ScanBase):
         nsigrows = len(self._sigonrows) + len(self._sigoffrows)
         self._nrows = nsigrows
 
-        self._nchan = len(self._sigcalon[0])
+        self._nchan = gbtfits.nchan(self._bintable_index)
         self._tsys = None
         self._exposure = None
         self._calibrated = None

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -123,7 +123,7 @@ def gbt_timestamp_to_time(timestamp):
     return Time(t, scale="utc")
 
 
-def generate_tag(values, hashlen):
+def generate_tag(values, hashlen, add_time=True):
     """
     Generate a unique tag based on input values.  A hash object is
     created from the input values using SHA256, and a hex representation is created.
@@ -135,6 +135,8 @@ def generate_tag(values, hashlen):
         The values to use in creating the hash object
     hashlen : int, optional
         The length of the returned hash string.
+    add_time: bool
+        Add the time of the call to the values for hash generation.
 
     Returns
     -------
@@ -142,6 +144,8 @@ def generate_tag(values, hashlen):
         The hash string
 
     """
+    if add_time:
+        values.append(Time.now().value)
     data = "".join(map(str, values))
     hash_object = hashlib.sha256(data.encode())
     unique_id = hash_object.hexdigest()

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -36,7 +36,37 @@ def select_from(key, value, df):
         The subselected DataFrame
 
     """
+    # nb this fails if value is None
     return df[(df[key] == value)]
+
+
+def eliminate_flagged_rows(df, flag):
+    """
+    Remove rows from an index (selection) where all channels have been flagged.
+
+    Parameters
+    ----------
+    df : `~pandas.DataFrame`
+        The input dataframe from which flagged rows will be removed.
+    flag : `~pandas.DataFrame`
+        The flag dataframe.  Should be the result of e.g. `~util.Flag.final`
+
+    Returns
+    -------
+        A data frame which is the input data frame with flagged rows removed.
+    """
+    if len(flag) > 0:
+        # in the final flagging selection any rows that have CHAN=ALL_CHANNELS
+        # indicate that the entire row is flagged
+        ff = flag[flag["CHAN"].isin([ALL_CHANNELS])]
+        flagged_rows = set(ff["ROW"])
+        if len(flagged_rows) > 0:
+            userows = list(set(df["ROW"]) - flagged_rows)
+            if len(userows) > 0:
+                return df[df["ROW"].isin(userows)]
+            else:
+                return df.iloc[0:0]  # all rows removed
+    return df
 
 
 def indices_where_value_changes(colname, df):

--- a/src/dysh/util/selection.py
+++ b/src/dysh/util/selection.py
@@ -318,12 +318,12 @@ class SelectionBase(DataFrame):
             If one or more keywords are unrecognized
 
         """
-        ignorekeys = ["PROPOSED_CHANNEL_RULE"]
+        # ignorekeys = ["PROPOSED_CHANNEL_RULE"]
         unrecognized = []
         ku = [k.upper() for k in keys]
-        for k in ignorekeys:
-            if k in ku:
-                ku.remove(k)
+        # for k in ignorekeys:
+        #    if k in ku:
+        #        ku.remove(k)
         for k in ku:
             if k not in self and k not in self._aliases:
                 unrecognized.append(k)
@@ -519,12 +519,14 @@ class SelectionBase(DataFrame):
             True if the selection resulted in a new fule, False if not (no data selected)
 
         """
-        self._check_keys(kwargs.keys())
-        row = {}
+        # pop these before check_keys, which is intended to check SDFITS keywords
+        proposed_channel_rule = kwargs.pop("proposed_channel_rule", None)
         # if called via _select_from_mixed_kwargs, then we want to merge all the
         # selections
         df = kwargs.pop("startframe", self)
-        proposed_channel_rule = kwargs.pop("proposed_channel_rule", None)
+        self._check_keys(kwargs.keys())
+        row = {}
+
         single_value_queries = None
         multi_value_queries = None
         for k, v in list(kwargs.items()):

--- a/src/dysh/util/selection.py
+++ b/src/dysh/util/selection.py
@@ -432,32 +432,15 @@ class SelectionBase(DataFrame):
            True if a duplicate was found, False if not.
 
         """
-        #        Raises
-        #        ------
-        #        Exception
-        #            If an identical rule (DataFrame) has already been added.
-        # print(f"checkinf for duplicates with {df}")
         for _id, s in self._selection_rules.items():
-            # if s.dropna(axis=1, how="all").equals(df.dropna(axis=1, how="all")):
             tag = self._table.loc[_id]["TAG"]
-            # print(f"Checking {tag}")
             if s.equals(df):
                 tag = self._table.loc[_id]["TAG"]
-                print(
-                    f"A rule that results in an identical selection has already been added: ID: {_id}, TAG:{tag}."
-                    " Ignoring."
-                )
-                # raise Exception(
                 warnings.warn(
                     f"A rule that results in an identical selection has already been added: ID: {_id}, TAG:{tag}."
                     " Ignoring."
                 )
                 return True
-                # )
-            # else:
-            #    diff = s.compare(df, align_axis=1)
-            #    tag = self._table.loc[_id]["TAG"]
-            #   print(f"DID not find duplicates for {tag} {diff=}")
         return False
 
     def _addrow(self, row, dataframe, tag=None):


### PR DESCRIPTION
The fix for this issue was not as simple as initially thought.  While the `setmask` argument was indeed missing from GBTFITSLoad.getspec/rawspectrum/rawspectra, there was a deeper issue that completely flagged rows were not removed in calibration routines (before create of relevant Scan class).   The fix for this necessitated a few other changes in selection.py having to do with how rules are constructed and compared. 

* add setmask argument to `GBTFITSLoad.xxspecxx`
* add `eliminate_flagged_rows` method to util.core
* ensure rows with all channels flagged are eliminated during calibration routines by calling the above
* add timestamp value to `util.core.generate_tag` to ensure tags are always unique
* ensure flagged channels are correctly represented in Flag selection rules (DataFrames) and `flag_channel_selection` `attribute
* add regression test for the issue as reported
* update test_getspec to make sure that setmask works as advertised