### PR TITLE
Issue 174

### DIFF
--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -19,6 +19,8 @@ from astropy.modeling.polynomial import Chebyshev1D, Hermite1D, Legendre1D, Poly
 from scipy import ndimage
 from specutils import SpectralRegion
 from specutils.fitting import fit_continuum
+from specutils.fitting.fitmodels import _strip_units_from_model
+from specutils.utils import QuantityModel
 
 from ..coordinates import veltofreq
 from ..log import log_function_call, logger
@@ -360,7 +362,9 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
     model = minimum_string_match(kwargs_opts["model"], list(available_models.keys()))
     if model == None:
         raise ValueError(f'Unrecognized input model {kwargs["model"]}. Must be one of {list(available_models.keys())}')
-    selected_model = available_models[model](degree=order)
+    sa_min = spectrum.spectral_axis.min().value
+    sa_max = spectrum.spectral_axis.max().value
+    selected_model = available_models[model](degree=order, domain=(sa_max, sa_min))
 
     _valid_exclude_actions = ["replace", "append", None]
     if kwargs_opts["exclude_action"] not in _valid_exclude_actions:
@@ -385,13 +389,26 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
         # exist (they will be a list of SpectralRegions or None)
         regionlist = p._exclude_regions
     print(f"EXCLUDING {regionlist}")
-    return fit_continuum(
+
+    fitted_model = fit_continuum(
         spectrum=p,
         model=selected_model,
         fitter=fitter,
         exclude_regions=regionlist,
         exclude_region_upper_bounds=exclude_region_upper_bounds,
     )
+
+    # astropy's Polynomial1D model does not work well when using
+    # a domain other than (-1,1), so we need to remove the units
+    # of the model. We use `specutils` methods to do so. This has the
+    # downside that the uncertainties of the model are removed.
+    if not isinstance(fitted_model, QuantityModel):
+        strip_model, _, _ = _strip_units_from_model(fitted_model, p)
+        strip_model.domain = fitted_model.domain
+        strip_model.window = fitted_model.window
+        fitted_model = QuantityModel(strip_model, p.spectral_axis.unit, p.flux.unit)
+
+    return fitted_model
 
 
 def mean_tsys(calon, caloff, tcal, mode=0, fedge=0.1, nedge=None):

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -454,6 +454,8 @@ def exclude_to_region_list(exclude, spectrum, fix_exclude=True):
 @log_function_call()
 def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **kwargs):
     """Fit a baseline to `spectrum`.
+    The code uses `~astropy.modeling.fitting.Fitter` and `~astropy.modeling.polynomial` to compute the baseline.
+    See the documentation for those modules for details.
 
     Parameters
     ----------
@@ -485,8 +487,8 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
 
     model : str
         One of 'polynomial' or 'chebyshev', Default: 'polynomial'
-    fitter : `~astropy.fitting._FitterMeta`
-        The fitter to use. Default: `~astropy.fitter.LinearLSQFitter` (with `calc_uncertaintes=True`).
+    fitter : `~astropy.modeling.fitting.Fitter`
+        The fitter to use. Default: `~astropy.modeling.fitter.LinearLSQFitter` (with `calc_uncertaintes=True`).
         Be careful when choosing a different fitter to be sure it is optimized for this problem.
     exclude_region_upper_bounds : bool
         Makes the upper bound of any excision region(s) inclusive.
@@ -494,10 +496,9 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
 
     Returns
     -------
-    models : list of `~astropy.modeling.Model`
-        The list of models that contain the fitted model parameters.
+    model : `~specutils.utils.QuantityModel`
+        Best fit model.
         See `~specutils.fitting.fit_continuum`.
-
     """
     kwargs_opts = {
         #'show': False,

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -194,41 +194,41 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         Parameters
         ----------
-            degree : int
-                The degree of the polynomial series, a.k.a. baseline order
-            exclude : list of 2-tuples of int or ~astropy.units.Quantity, or ~specutils.SpectralRegion
-                List of region(s) to exclude from the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
-                In channel units.
+        degree : int
+            The degree of the polynomial series, a.k.a. baseline order
+        exclude : list of 2-tuples of int or ~astropy.units.Quantity, or ~specutils.SpectralRegion
+            List of region(s) to exclude from the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
+            In channel units.
 
-                Examples:
+            Examples:
 
-                One channel-based region: [11,51]
+            One channel-based region: [11,51]
 
-                Two channel-based regions: [(11,51),(99,123)].
+            Two channel-based regions: [(11,51),(99,123)].
 
-                One ~astropy.units.Quantity region: [110.198*u.GHz,110.204*u.GHz].
+            One ~astropy.units.Quantity region: [110.198*u.GHz,110.204*u.GHz].
 
-                One compound `~specutils.SpectralRegion`: SpectralRegion([(110.198*u.GHz,110.204*u.GHz),(110.196*u.GHz,110.197*u.GHz)]).
+            One compound `~specutils.SpectralRegion`: SpectralRegion([(110.198*u.GHz,110.204*u.GHz),(110.196*u.GHz,110.197*u.GHz)]).
 
-                Default: no exclude region
+            Default: no exclude region
 
-            include: list of 2-tuples of int (currently units not supported yet, pending issue 251/260)
+        include: list of 2-tuples of int (currently units not supported yet, pending issue 251/260)
 
-            model : str
-                One of 'polynomial' 'chebyshev', 'legendre', or 'hermite'
-                Default: 'chebyshev'
-            fitter  :  `~astropy.fitting._FitterMeta`
-                The fitter to use. Default: `~astropy.fitter.LinearLSQFitter` (with `calc_uncertaintes=True`).
-                Be care when choosing a different fitter to be sure it is optimized for this problem.
-            remove : bool
-                If True, the baseline is removed from the spectrum. Default: False
-            normalize : bool
-                If True, the frequency axis is internally rescaled from 0..1
-                to avoid roundoff problems (and make the coefficients slightly more
-                understandable). This is usually needed for a polynomial, though overkill
-                for the others who do their own normalization.
-                CAVEAT:   with normalize=True, you cannot undo a baseline fit.
-                Default: False
+        model : str
+            One of 'polynomial' 'chebyshev', 'legendre', or 'hermite'
+            Default: 'chebyshev'
+        fitter  :  `~astropy.fitting._FitterMeta`
+            The fitter to use. Default: `~astropy.fitter.LinearLSQFitter` (with `calc_uncertaintes=True`).
+            Be care when choosing a different fitter to be sure it is optimized for this problem.
+        remove : bool
+            If True, the baseline is removed from the spectrum. Default: False
+        normalize : bool
+            If True, the frequency axis is internally rescaled from 0..1
+            to avoid roundoff problems (and make the coefficients slightly more
+            understandable). This is usually needed for a polynomial, though overkill
+            for the others who do their own normalization.
+            CAVEAT:   with normalize=True, you cannot undo a baseline fit.
+            Default: False
 
         """
         # fmt: on

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -125,7 +125,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
             self._resolution = 1
 
     def _len(self):
-        """return the size of the Spectrum in the spectral dimension.
+        """return the size of the `Spectrum` in the spectral dimension.
         @todo __len__  has unintended consquences, yuck.
         """
         return len(self.frequency)
@@ -160,12 +160,9 @@ class Spectrum(Spectrum1D, HistoricalBase):
     def baseline(self, degree, exclude=None, include=None, **kwargs):
         # fmt: off
         """
-        Compute and optionally remove a baseline. The model for the
-        baseline can be either a
-        `1D polynomial model <https://docs.astropy.org/en/latest/api/astropy.modeling.polynomial.Polynomial1D.html>`_ or a
-        `1D Chebyshev polynomial of the first kind <https://docs.astropy.org/en/latest/api/astropy.modeling.polynomial.Chebyshev1D.html>`_.
-        The code uses `~astropy.modeling`
-        and `~astropy.fitter` to compute the baseline. See the documentation for those modules.
+        Compute and optionally remove a baseline.
+        The code uses `~astropy.modeling.fitting.Fitter` and `~astropy.modeling.polynomial` to compute the baseline.
+        See the documentation for those modules for details.
         This method will set the `baseline_model` attribute to the fitted model function which can be evaluated over a domain.
 
         Note that `include` and `exclude` are mutually exclusive. If both are present, only `include` will be used.
@@ -183,21 +180,21 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
             Two channel-based regions: [(11,51),(99,123)].
 
-            One ~astropy.units.Quantity region: [110.198*u.GHz,110.204*u.GHz].
+            One `~astropy.units.Quantity` region: [110.198*u.GHz,110.204*u.GHz].
 
             One compound `~specutils.SpectralRegion`: SpectralRegion([(110.198*u.GHz,110.204*u.GHz),(110.196*u.GHz,110.197*u.GHz)]).
 
             Default: no exclude region
 
-        include: list of 2-tuples of int or `~astropy.units.Quantity`, or `~specutils.SpectralRegion`
-            List of region(s) to include in the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
+        include : list of 2-tuples of int or `~astropy.units.Quantity`, or `~specutils.SpectralRegion`
+            List of region(s) to include in the fit. The tuple(s) represent a range in the form [lower,upper], inclusive.
             See `exclude` for examples.
         model : str
-            One of 'polynomial' 'chebyshev', 'legendre', or 'hermite'
+            One of 'polynomial', 'chebyshev', 'legendre', or 'hermite'
             Default: 'chebyshev'
-        fitter  :  `~astropy.fitting._FitterMeta`
-            The fitter to use. Default: `~astropy.fitter.LinearLSQFitter` (with `calc_uncertaintes=True`).
-            Be care when choosing a different fitter to be sure it is optimized for this problem.
+        fitter : `~astropy.modeling.fitting.Fitter`
+            The fitter to use. Default: `~astropy.modeling.fitting.LinearLSQFitter` (with `calc_uncertaintes=True`).
+            Be careful when choosing a different fitter to be sure it is optimized for this problem.
         remove : bool
             If True, the baseline is removed from the spectrum. Default: False
         """
@@ -210,12 +207,11 @@ class Spectrum(Spectrum1D, HistoricalBase):
         }
         kwargs_opts.update(kwargs)
 
-        # include= and exclude= are mutually exclusive, but we allow include=
-        # if include is used, transform it to exclude=
+        # `include` and `exclude` are mutually exclusive, but we allow `include`
+        # if `include` is used, transform it to `exclude`.
         if include != None:
             if exclude != None:
                 logger.info(f"Warning: ignoring exclude={exclude}")
-            nchan = len(self._spectral_axis)
             exclude = core.include_to_exclude_spectral_region(include, self)
 
         self._baseline_model = baseline(self, degree, exclude, **kwargs)
@@ -249,14 +245,14 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         Parameters
         ----------
-            exclude : list of 2-tuples of int or ~astropy.units.Quantity, or ~specutils.SpectralRegion
-                List of region(s) to exclude from the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
-                In channel units.
+        exclude : list of 2-tuples of int or ~astropy.units.Quantity, or ~specutils.SpectralRegion
+            List of region(s) to exclude from the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
+            In channel units.
 
-                Examples: One channel-based region: [11,51],
-                          Two channel-based regions: [(11,51),(99,123)].
-                          One ~astropy.units.Quantity region: [110.198*u.GHz,110.204*u.GHz].
-                          One compound ~specutils.SpectralRegion: SpectralRegion([(110.198*u.GHz,110.204*u.GHz),(110.196*u.GHz,110.197*u.GHz)]).
+            Examples: One channel-based region: [11,51],
+                      Two channel-based regions: [(11,51),(99,123)].
+                      One ~astropy.units.Quantity region: [110.198*u.GHz,110.204*u.GHz].
+                      One compound ~specutils.SpectralRegion: SpectralRegion([(110.198*u.GHz,110.204*u.GHz),(110.196*u.GHz,110.197*u.GHz)]).
 
         """
         pass
@@ -726,18 +722,18 @@ class Spectrum(Spectrum1D, HistoricalBase):
         self.meta["VELDEF"] = change_ctype(self.meta["VELDEF"], self._velocity_frame)
 
     def with_frame(self, toframe):
-        """Return a copy of this Spectrum with a new coordinate reference frame.
+        """Return a copy of this `Spectrum` with a new coordinate reference frame.
 
         Parameters
         ----------
-        toframe - str, ~astropy.coordinates.BaseCoordinateFrame, or ~astropy.coordinates.SkyCoord
+        toframe - str, `~astropy.coordinates.BaseCoordinateFrame`, or `~astropy.coordinates.SkyCoord`
             The coordinate reference frame identifying string, as used by astropy, e.g. 'hcrs', 'icrs', etc.,
             or an actual coordinate system instance
 
         Returns
         -------
-        spectrum : `~dysh.spectra.Spectrum`
-            A new Spectrum object
+        spectrum : `Spectrum`
+            A new `Spectrum` object with the rest frame set to `toframe`.
         """
 
         s = self._copy()
@@ -746,11 +742,11 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
     @log_call_to_history
     def set_convention(self, doppler_convention):
-        """Set the velocity convention of this Spectrum.  The spectral axis of this Spectrum will be replaced
+        """Set the velocity convention of this `Spectrum`.  The spectral axis of this `Spectrum` will be replaced
         with a new spectral axis with the input velocity convention.  The header 'VELDEF' value will
         be changed accordingly.
 
-        To make a copy of this Spectrum with a new velocity convention instead, use `with_velocity_convention`.
+        To make a copy of this `Spectrum` with a new velocity convention instead, use `with_velocity_convention`.
 
         Parameters
         ----------
@@ -765,7 +761,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         self.meta["VELDEF"] = replace_convention(self.meta["VELDEF"], doppler_convention)
 
     def with_velocity_convention(self, doppler_convention):
-        """Returns a copy of this Spectrum with the input velocity convention.  The header 'VELDEF' value will
+        """Returns a copy of this `Spectrum` with the input velocity convention.  The header 'VELDEF' value will
         be changed accordingly.
 
         Parameters
@@ -775,8 +771,8 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         Returns
         -------
-        spectrum : `~dysh.spectra.Spectrum`
-            A new Spectrum object
+        spectrum : `Spectrum`
+            A new `Spectrum` object with `doppler_convention` as its Doppler convention.
         """
         if False:
             # this doesn't work.
@@ -921,7 +917,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         Returns
         -------
-        spectrum : `~dysh.spectra.Spectrum`
+        spectrum : `Spectrum`
             The spectrum object
         """
 
@@ -1030,8 +1026,8 @@ class Spectrum(Spectrum1D, HistoricalBase):
     @classmethod
     def make_spectrum(cls, data, meta, use_wcs=True, observer_location=None, observer=None):
         # , shift_topo=False):
-        """Factory method to create a Spectrum object from a data and header.  The the data are masked,
-        the Spectrum mask will be set to the data mask.
+        """Factory method to create a `Spectrum` object from a data and header.  The the data are masked,
+        the `Spectrum` mask will be set to the data mask.
 
         Parameters
         ----------
@@ -1054,7 +1050,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         Returns
         -------
-        spectrum : `~dysh.spectra.Spectrum`
+        spectrum : `Spectrum`
             The spectrum object
         """
         # @todo generic check_required method since I now have this code in two places (coordinates/core.py).

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -1386,7 +1386,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         )
 
     def average(self, spectra, weights="tsys", align=False):
-        """
+        r"""
         Average this `Spectrum` with `spectra`.
         The resulting `average` will have an exposure equal to the sum of the exposures,
         and coordinates and system temperature equal to the weighted average of the coordinates and system temperatures.

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -241,6 +241,11 @@ class Spectrum(Spectrum1D, HistoricalBase):
         }
         kwargs_opts.update(kwargs)
 
+        # Switch to GHz to avoid poorly conditioned fit warnings due to large x-axis values.
+        # See Issue 174.
+        org_unit = self._spectral_axis.unit
+        self._spectral_axis = self._spectral_axis.to("GHz")
+
         if kwargs_opts["normalize"]:
             print("Warning: baseline fit done in [0,1) space, even though it might say Hz (issue ###)")
             spectral_axis = deepcopy(self._spectral_axis)  # save the old axis
@@ -268,6 +273,8 @@ class Spectrum(Spectrum1D, HistoricalBase):
         if kwargs_opts["normalize"]:
             self._spectral_axis = spectral_axis
             del spectral_axis
+
+        self._spectral_axis = self._spectral_axis.to(org_unit)
 
     # baseline
     @log_call_to_history

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -627,7 +627,7 @@ class TestSpectrum:
         test_single_baseline(sdf, ex_reg, order, "legendre", gbtidl_two_reg)
         test_single_baseline(sdf, ex_reg, order, "hermite", gbtidl_two_reg)
         # TODO: polynomial fit test fails until issues 174, 252 are fixed
-        # test_single_baseline(sdf,ex_reg,order,'polynomial',gbtidl_two_reg)
+        test_single_baseline(sdf, ex_reg, order, "polynomial", gbtidl_two_reg)
 
         ex_reg = None
         test_single_baseline(sdf, ex_reg, order, "chebyshev", gbtidl_no_reg)

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -649,7 +649,7 @@ class TestSpectrum:
             fit_val = getattr(s._baseline_model.unitless_model, pn).value
             in_val = pcoef[::-1][int(pn[-1])]
             assert (in_val - fit_val) / in_val < 0.1
-        
+
         # Test with units. Nothing to compare to though.
         dysh_spec = sdf.getspec(0)
         kms = u.km / u.s

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import patch
 
 import astropy.units as u
@@ -626,8 +627,12 @@ class TestSpectrum:
         test_single_baseline(sdf, ex_reg, order, "chebyshev", gbtidl_two_reg)
         test_single_baseline(sdf, ex_reg, order, "legendre", gbtidl_two_reg)
         test_single_baseline(sdf, ex_reg, order, "hermite", gbtidl_two_reg)
-        # TODO: polynomial fit test fails until issues 174, 252 are fixed
         test_single_baseline(sdf, ex_reg, order, "polynomial", gbtidl_two_reg)
 
         ex_reg = None
         test_single_baseline(sdf, ex_reg, order, "chebyshev", gbtidl_no_reg)
+
+        # Test that no warnings are issued.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.ps0.baseline(model="poly", degree=2)


### PR DESCRIPTION
This PR fixes issue #174 by using the domain parameter of the `astropy.modeling.polynomial` models. However, this solution does not fully work for `Polynomial1D`, since when using `domain != (-1,1)` you cannot evaluate a `Polynomial1D` if it has units (or at least I couldn't figure out how). To solve this, I chose to remove the units from the `Polynomial1D` model using the functions provided by `specutils`. This has the downside of losing some information, like the uncertainties in the estimated parameters -- which are already lost for the other models since they go through this unit stripping.