### PR TITLE
Issue 260

### DIFF
--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -209,7 +209,7 @@ def include_to_exclude_spectral_region(include, refspec):
 
     refspec: `~spectra.spectrum.Spectrum`
         The reference spectrum whose spectral axis will be used
-        when converting between include and axis units (e.g. channels to GHz).
+        when converting between `include` and axis units (e.g. channels to GHz).
 
     Returns
     -------
@@ -237,12 +237,12 @@ def include_to_exclude_spectral_region(include, refspec):
 
 
 def exclude_to_spectral_region(exclude, refspec, fix_exclude=True):
-    """Convert an exclude list to a list of ~specutuls.SpectralRegion.
+    """Convert `exclude` to a `~specutils.SpectralRegion`.
 
     Parameters
     ----------
     exclude : list of 2-tuples of int or `~astropy.units.Quantity`, or `~specutils.SpectralRegion`
-        List of region(s) to exclude from the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
+        List of region(s) to exclude. The tuple(s) represent a range in the form [lower,upper], inclusive.
         Examples:
 
         One channel-based region:
@@ -263,14 +263,15 @@ def exclude_to_spectral_region(exclude, refspec, fix_exclude=True):
 
     refspec: `~spectra.spectrum.Spectrum`
         The reference spectrum whose spectral axis will be used
-        when converting between exclude and axis units (e.g. channels to GHz).
+        when converting between `exclude` and axis units (e.g. channels to GHz).
     fix_exclude: bool
-        If True, fix exclude regions that are out of bounds of the specctral axis to be within the spectral axis. Default:False
+        If True, fix exclude regions that are out of bounds of the spectral axis to be within the spectral axis.
+        Default: True
 
     Returns
     -------
-    sr : `~specutil.SpectralRegion`
-        A `~specutil.SpectralRegion` corresponding to `exclude`.
+    sr : `~specutils.SpectralRegion`
+        A `~specutils.SpectralRegion` corresponding to `exclude`.
     """
 
     p = refspec
@@ -320,8 +321,8 @@ def spectral_region_to_unit(spectral_region, refspec, unit=None):
 
     Parameters
     ----------
-    spectral_region : `~specutil.SpectralRegion`
-        `~specutil.SpectralRegion` whose units will be converted.
+    spectral_region : `~specutils.SpectralRegion`
+        `~specutils.SpectralRegion` whose units will be converted.
     refspec : `~spectra.spectrum.Spectrum`
         The reference spectrum whose spectral axis will be used
         when converting to `unit` (e.g. channels to GHz).
@@ -330,7 +331,7 @@ def spectral_region_to_unit(spectral_region, refspec, unit=None):
 
     Returns
     -------
-    spectral_region : `~specutil.SpectralRegion`
+    spectral_region : `~specutils.SpectralRegion`
         SpectralRegion with units of `unit`.
     """
 
@@ -347,18 +348,18 @@ def spectral_region_to_unit(spectral_region, refspec, unit=None):
 
 def spectral_region_to_list(spectral_region):
     """
-    Turn `spectral_region` into a list of `~specutil.SpectralRegion`.
+    Turn `spectral_region` into a list of `~specutils.SpectralRegion`.
     Each subregion in `spectral_region` will be a list element.
 
     Parameters
     ----------
-    spectral_region : `~specutil.SpectralRegion`
-        `~specutil.SpectralRegion` to convert into a list of `~specutil.SpectralRegion`.
+    spectral_region : `~specutils.SpectralRegion`
+        `~specutils.SpectralRegion` to convert into a list of `~specutils.SpectralRegion`.
 
     Returns
     -------
-    region_list : list of `~specutil.SpectralRegion`
-        Subregions of `spectral_region` in a list of `~specutil.SpectralRegion`.
+    region_list : list of `~specutils.SpectralRegion`
+        Subregions of `spectral_region` in a list of `~specutils.SpectralRegion`.
     """
 
     region_list = []
@@ -403,13 +404,13 @@ def exclude_to_mask(exclude, refspec):
 
 def exclude_to_region_list(exclude, spectrum, fix_exclude=True):
     """
-    Convert an exclusion region, `exclude`, to a list of `~SpectralRegion`.
+    Convert an exclusion region, `exclude`, to a list of `~specutils.SpectralRegion`.
     This is used for baseline fitting.
 
     Parameters
     ----------
     exclude : list of 2-tuples of int or `~astropy.units.Quantity`, or `~specutils.SpectralRegion`
-        List of region(s) to exclude from the fit. The tuple(s) represent a range in the form [lower,upper], inclusive.
+        List of region(s) to exclude. The tuple(s) represent a range in the form [lower,upper], inclusive.
         Examples:
 
         One channel-based region:
@@ -430,14 +431,15 @@ def exclude_to_region_list(exclude, spectrum, fix_exclude=True):
 
     spectrum : `~spectra.spectrum.Spectrum`
         The reference spectrum whose spectral axis will be used
-        when converting between exclude and axis units (e.g. channels to GHz).
+        when converting between `exclude` and axis units (e.g. channels to GHz).
     fix_exclude : bool
-        See `~spectra.core.exclude_to_spectral_region` for details. Default: True
+        See `~spectra.core.exclude_to_spectral_region` for details.
+        Default: True
 
     Returns
     -------
-    region_list : list of `~specutil.SpectralRegion`
-        Regions defined in `exclude` as a list of `~specutil.SpectralRegion`.
+    region_list : list of `~specutils.SpectralRegion`
+        Regions defined in `exclude` as a list of `~specutils.SpectralRegion`.
     """
 
     spectral_region = exclude_to_spectral_region(exclude, spectrum, fix_exclude=fix_exclude)
@@ -458,7 +460,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
     order : int
         The order of the polynomial series, a.k.a. baseline order.
     exclude : list of 2-tuples of int or `~astropy.units.Quantity`, or `~specutils.SpectralRegion`
-        List of region(s) to exclude from the fit.  The tuple(s) represent a range in the form [lower,upper], inclusive.
+        List of region(s) to exclude from the fit. The tuple(s) represent a range in the form [lower,upper], inclusive.
         Examples:
 
         One channel-based region:
@@ -492,7 +494,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
     -------
     models : list of `~astropy.modeling.Model`
         The list of models that contain the fitted model parameters.
-        See `~specutuls.fitting.fit_continuum`.
+        See `~specutils.fitting.fit_continuum`.
 
     """
     kwargs_opts = {

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -207,13 +207,13 @@ def exclude_to_region(exclude, refspec, fix_exclude=True):
     if exclude is not None:
         # A single SpectralRegion was given.
         if isinstance(exclude, SpectralRegion):
-            b = exclude.bounds
-            regionlist.append(exclude)
-        # list of int or Quantity or SpectralRegion was given.
+            sr = exclude
+        # `list` of `int` or `Quantity` or `SpectralRegion` was given.
         else:
             # If user provided a single list, we have to
             # turn it into a list of tuples. If SpectralRegion
             # took a list argument, we wouldn't have to do this.
+            print(exclude)
             if type(exclude[0]) is not tuple:
                 it = iter(exclude)
                 exclude = list(zip(it, it))
@@ -232,11 +232,18 @@ def exclude_to_region(exclude, refspec, fix_exclude=True):
                         warnings.warn(msg)
                 # If the spectral_axis is decreasing, flip it.
                 sr = SpectralRegion(sa[exclude][:, ::o])
-            # The continuum fitting routines use a list of SpectralRegions as input.
-            for r in sr.subregions:
-                regionlist.append(SpectralRegion([r]))
 
-            return regionlist
+        # Change units to match those of the `Spectrum`.
+        qt = sr.as_table()
+        lb = qt["lower_bound"].to(p._spectral_axis.unit, equivalencies=p.equivalencies)
+        ub = qt["upper_bound"].to(p._spectral_axis.unit, equivalencies=p.equivalencies)
+        lsr = list(zip(lb, ub))
+
+        # The continuum fitting routines use a list of `SpectralRegions` as input.
+        for r in lsr:
+            regionlist.append(SpectralRegion([r]))
+
+        return regionlist
 
 
 def region_to_axis_indices(region, refspec):

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -539,7 +539,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
         # use the spectrum's preset exclude regions if they
         # exist (they will be a list of SpectralRegions or None)
         regionlist = p._exclude_regions
-    print(f"EXCLUDING {regionlist}")
+    logger.info(f"EXCLUDING {regionlist}")
     return fit_continuum(
         spectrum=p,
         model=selected_model,

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -256,7 +256,8 @@ class Spectrum(Spectrum1D, HistoricalBase):
             if exclude != None:
                 print(f"Warning: ignoring exclude={exclude}")
             nchan = len(self._spectral_axis)
-            exclude = self._toggle_sections(nchan, include)
+            exclude = core.include_to_exclude_spectral_region(include, self)
+            # exclude = self._toggle_sections(nchan, include)
 
         self._baseline_model = baseline(self, degree, exclude, **kwargs)
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -631,3 +631,33 @@ class TestSpectrum:
 
         ex_reg = None
         test_single_baseline(sdf, ex_reg, order, "chebyshev", gbtidl_no_reg)
+
+    def test_baseline_include(self):
+        """
+        Test for comparing GBTIDL baseline to dysh baselines
+        using inclusion regions.
+        """
+
+        def test_single_baseline(sdf, in_reg, order, model, gbtidl_bmodel, exclude_region_upper_bounds=True):
+            """For use with TestSpectrum.test_baseline()"""
+            dysh_spec = sdf.getspec(0)
+            temp_bmodel = np.copy(dysh_spec.data)
+            dysh_spec.baseline(
+                order, include=in_reg, remove=True, model=model, exclude_region_upper_bounds=exclude_region_upper_bounds
+            )
+            dysh_bmodel = temp_bmodel - np.copy(dysh_spec.data)
+            diff = np.sum(np.abs(dysh_bmodel - gbtidl_bmodel))
+            assert diff < 1.5e-6
+
+        data_dir = get_project_testdata() / "AGBT17A_404_01"
+        sdf_file = data_dir / "AGBT17A_404_01_scan_19_prebaseline.fits"
+        sdf = GBTFITSLoad(sdf_file)
+        gbtidl_two_reg = loadfits(data_dir / "AGBT17A_404_01_scan_19_bmodel.fits")
+        gbtidl_no_reg = loadfits(data_dir / "AGBT17A_404_01_scan_19_noregion_bmodel.fits")
+
+        order = 3
+        in_reg = [(99, 381), (449, 721)]
+
+        test_single_baseline(sdf, in_reg, order, "chebyshev", gbtidl_two_reg)
+        test_single_baseline(sdf, in_reg, order, "legendre", gbtidl_two_reg)
+        test_single_baseline(sdf, in_reg, order, "hermite", gbtidl_two_reg)

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -632,6 +632,16 @@ class TestSpectrum:
         ex_reg = None
         test_single_baseline(sdf, ex_reg, order, "chebyshev", gbtidl_no_reg)
 
+        # Test with units. Nothing to compare to though.
+        dysh_spec = sdf.getspec(0)
+        kms = u.km / u.s
+        ex_reg = [(0 * kms, 4200 * kms), (6000 * kms, 7000 * kms), (8800 * kms, 90000 * kms)]
+        dysh_spec.baseline(order, ex_reg, model="chebyshev")
+        ex_reg = [(1 * u.GHz, 1.38 * u.GHz), (1.388 * u.GHz, 1.392 * u.GHz), (1.4 * u.GHz, 2 * u.GHz)]
+        dysh_spec.baseline(order, ex_reg, model="chebyshev")
+        ex_reg = [21 * u.cm, 21.5 * u.cm]
+        dysh_spec.baseline(order, ex_reg, model="chebyshev")
+
     def test_baseline_include(self):
         """
         Test for comparing GBTIDL baseline to dysh baselines
@@ -661,3 +671,13 @@ class TestSpectrum:
         test_single_baseline(sdf, in_reg, order, "chebyshev", gbtidl_two_reg)
         test_single_baseline(sdf, in_reg, order, "legendre", gbtidl_two_reg)
         test_single_baseline(sdf, in_reg, order, "hermite", gbtidl_two_reg)
+
+        # Test with units. Nothing to compare to though.
+        dysh_spec = sdf.getspec(0)
+        kms = u.km / u.s
+        in_reg = [(4200 * kms, 6000 * kms), (7000 * kms, 8800 * kms)]
+        dysh_spec.baseline(order, include=in_reg, model="chebyshev")
+        in_reg = [(1.38 * u.GHz, 1.388 * u.GHz), (1.392 * u.GHz, 1.4 * u.GHz)]
+        dysh_spec.baseline(order, include=in_reg, model="chebyshev")
+        in_reg = [21 * u.cm, 21.5 * u.cm]
+        dysh_spec.baseline(order, include=in_reg, model="chebyshev")


### PR DESCRIPTION
This PR expands the use of exclusion/inclusion regions to accept multiple ranges with units or not.

Once finished this will fix issue #260.

This also adds tests for baseline fitting using `include`, and using regions with units. The tests with units do not check for "quality", just that the region selection does not error.