### PR TITLE
Fix SyntaxWarning for invalid escape sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,12 @@ line-length = 120
 
 [tool.pyright]
 reportImplicitStringConcatenation = false
+
 [tool.ruff]
+line-length = 120
+src = ["src", "benchmark", "notebooks"]
+
+[tool.ruff.lint]
 select = [
   "F",    # https://beta.ruff.rs/docs/rules/#pyflakes-f
   "E",    # https://beta.ruff.rs/docs/rules/#error-e
@@ -172,10 +177,8 @@ unfixable = ["B"]
 ignore = [
   "E741",  # ambiguous-variable-name
 ]
-line-length = 120
-src = ["src", "benchmark", "notebooks"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Ignore  in all `__init__.py` files
 "__init__.py" = ["E402", "F405", "F403"]
 "**/{tests,docs,tools}/*" = ["E402", "B011"]

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -412,7 +412,7 @@ class TestGBTFITSLoad:
         index_file = p / "AGBT20B_014_03.raw.vegas.A6.index"
         data_file = p / "AGBT20B_014_03.raw.vegas.A6.fits"
         g = gbtfitsload.GBTFITSLoad(data_file)
-        gbtidl_index = pd.read_csv(index_file, skiprows=10, sep="\s+")
+        gbtidl_index = pd.read_csv(index_file, skiprows=10, sep=r"\s+")
         assert np.all(g._index["INTNUM"] == gbtidl_index["INT"])
 
     def test_getps_smoothref(self):

--- a/src/dysh/util/gaincorrection.py
+++ b/src/dysh/util/gaincorrection.py
@@ -411,7 +411,7 @@ class GBTGainCorrection(BaseGainCorrection):
         zd=False,
         eps0=None,
     ) -> Union[float, np.array]:
-        """
+        r"""
         Scale the antenna temperature to a different brightness temperature unit.
 
         bunit : str
@@ -599,7 +599,7 @@ class GBTGainCorrection(BaseGainCorrection):
             raise NotImplementedError("Don't yet know how to get Tatm without the getForecasValues script")
 
     def _default_gbtidl_opacity(self, frequency: Quantity) -> float:
-        """Implementation of the GBTIDL method of computing zenith opacity.
+        r"""Implementation of the GBTIDL method of computing zenith opacity.
         This method is not recommended (even by GBTIDL!). It is implemented here for compatibility only.
 
         Parameters


### PR DESCRIPTION
Same issue as #119

This can be checked for via `ruff check --select W605`

