### PR TITLE
Cap astropy<7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "astropy",
+  "astropy<7",
   "ipython",
   "jplephem",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "astropy<7",
+  "astropy<7,>5",
   "ipython",
   "jplephem",
   "matplotlib",


### PR DESCRIPTION
dysh does not work with `astropy>=7`. This should help avoid using astropy7 with dysh.