### PR TITLE
Config file

### DIFF
--- a/src/dysh/config/__init__.py
+++ b/src/dysh/config/__init__.py
@@ -1,0 +1,13 @@
+"""Configuration"""
+
+# https://docs.astropy.org/en/stable/config/index.html#customizing-config-location-in-affiliated-packages
+
+import astropy.config as astropyconfig
+
+
+class ConfigNamespace(astropyconfig.ConfigNamespace):
+    rootname = "dysh"
+
+
+class ConfigItem(astropyconfig.ConfigItem):
+    rootname = "dysh"

--- a/src/dysh/config/__init__.py
+++ b/src/dysh/config/__init__.py
@@ -4,6 +4,9 @@
 
 import astropy.config as astropyconfig
 
+from dysh.config import core
+from dysh.config.core import *
+
 
 class ConfigNamespace(astropyconfig.ConfigNamespace):
     rootname = "dysh"
@@ -11,3 +14,10 @@ class ConfigNamespace(astropyconfig.ConfigNamespace):
 
 class ConfigItem(astropyconfig.ConfigItem):
     rootname = "dysh"
+
+
+__all__ = [
+    "core",
+    "ConfigNamespace",
+    "ConfigItem",
+] + core.__all__

--- a/src/dysh/config/core.py
+++ b/src/dysh/config/core.py
@@ -1,0 +1,227 @@
+"""Configuration core functions"""
+
+import contextlib
+import importlib
+import io
+import os
+import pkgutil
+import warnings
+from contextlib import nullcontext
+from pathlib import Path
+from textwrap import TextWrapper
+
+from astropy import config as ac
+from astropy.config import configuration as acc
+from astropy.utils import silence
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+__all__ = ["create_config_file", "get_config_dir_path"]
+
+
+# def create_config_file(package: str = "dysh", rootname: str = "dysh", overwrite: bool = False) -> bool:
+#    """
+#    Create the default configuration file for the specified `package`.
+#    If the file already exists, it is updated only if it has not been modified.
+#    Otherwise the `overwrite` flag is needed to overwrite it.
+#
+#    Parameters
+#    ----------
+#    package : str
+#        The package.
+#    rootname : str
+#        Name of the root configuration directory.
+#    overwrite : bool
+#        Force updating the file if it already exists.
+#
+#    Returns
+#    -------
+#    updated : bool
+#        If the profile was updated, `True`, otherwise `False`.
+#    """
+#
+#    return ac.create_config_file(package, rootname=rootname, overwrite=overwrite)
+
+
+def get_config_dir_path(rootname: str = "dysh") -> Path:
+    """
+    Determines the package configuration directory name and creates the
+    directory if it doesn't exist.
+
+    This directory is typically ``$HOME/.astropy/config``, but if the
+    XDG_CONFIG_HOME environment variable is set and the
+    ``$XDG_CONFIG_HOME/astropy`` directory exists, it will be that directory.
+    If neither exists, the former will be created and symlinked to the latter.
+
+    Parameters
+    ----------
+    rootname : str
+        Name of the root configuration directory. For example, if ``rootname =
+        'pkgname'``, the configuration directory would be ``<home>/.pkgname/``
+        rather than ``<home>/.dysh`` (depending on platform).
+
+    Returns
+    -------
+    configdir : Path
+        The absolute path to the configuration directory.
+    """
+
+    return ac.get_config_dir_path(rootname)
+
+
+def recursive_subclasses(klass):
+    """
+    Yield all subclasses of the given class, per:
+    https://adamj.eu/tech/2024/05/10/python-all-subclasses/
+    """
+    seen = set()
+    for subclass in klass.__subclasses__():
+        yield subclass
+        for subsubclass in recursive_subclasses(subclass):
+            if subsubclass not in seen:
+                seen.add(subsubclass)
+                yield subsubclass
+
+
+def generate_config(pkgname="astropy", filename=None, verbose=False):
+    """Generates a configuration file, from the list of `ConfigItem`
+    objects for each subpackage.
+
+    .. versionadded:: 4.1
+
+    Parameters
+    ----------
+    pkgname : str or None
+        The package for which to retrieve the configuration object.
+    filename : str or file-like or None
+        If None, the default configuration path is taken from `get_config`.
+
+    """
+    if verbose:
+        verbosity = nullcontext
+        filter_warnings = AstropyDeprecationWarning
+    else:
+        verbosity = silence
+        filter_warnings = Warning
+
+    package = importlib.import_module(pkgname)
+    with verbosity(), warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=filter_warnings)
+        for mod in pkgutil.walk_packages(path=package.__path__, prefix=package.__name__ + "."):
+            if mod.module_finder.path.endswith(("test", "tests")) or mod.name.endswith("setup_package"):
+                # Skip test and setup_package modules
+                continue
+            if mod.name.split(".")[-1].startswith("_"):
+                # Skip private modules
+                continue
+
+            with contextlib.suppress(ImportError):
+                importlib.import_module(mod.name)
+
+    wrapper = TextWrapper(initial_indent="## ", subsequent_indent="## ", width=78)
+
+    if filename is None:
+        filename = acc.get_config_filename(pkgname)
+
+    with contextlib.ExitStack() as stack:
+        if isinstance(filename, (str, os.PathLike)):
+            fp = stack.enter_context(open(filename, "w"))
+        else:
+            # assume it's a file object, or io.StringIO
+            fp = filename
+
+        # Parse the subclasses, ordered by their module name
+        # subclasses = ConfigNamespace.__subclasses__()
+        subclasses = recursive_subclasses(ac.ConfigNamespace)
+        processed = set()
+
+        for conf in sorted(subclasses, key=lambda x: x.__module__):
+            mod = conf.__module__
+
+            # Skip modules for other packages, e.g. astropy modules that
+            # would be imported when running the function for astroquery.
+            if mod.split(".")[0] != pkgname:
+                continue
+
+            # Check that modules are not processed twice, which can happen
+            # when they are imported in another module.
+            if mod in processed:
+                continue
+            else:
+                processed.add(mod)
+
+            print_module = True
+            for item in conf().values():
+                if print_module:
+                    # If this is the first item of the module, we print the
+                    # module name, but not if this is the root package...
+                    if item.module != pkgname:
+                        modname = item.module.replace(f"{pkgname}.", "")
+                        fp.write(f"[{modname}]\n\n")
+                    print_module = False
+
+                fp.write(wrapper.fill(item.description) + "\n")
+                if isinstance(item.defaultvalue, (tuple, list)):
+                    if len(item.defaultvalue) == 0:
+                        fp.write(f"# {item.name} = ,\n\n")
+                    elif len(item.defaultvalue) == 1:
+                        fp.write(f"# {item.name} = {item.defaultvalue[0]},\n\n")
+                    else:
+                        fp.write(f"# {item.name} =" f' {",".join(map(str, item.defaultvalue))}\n\n')
+                else:
+                    fp.write(f"# {item.name} = {item.defaultvalue}\n\n")
+
+
+def create_config_file(pkg: str = "dysh", rootname: str = "dysh", overwrite: bool = False) -> bool:
+    """
+    Create the default configuration file for the specified package.
+    If the file already exists, it is updated only if it has not been
+    modified.  Otherwise the ``overwrite`` flag is needed to overwrite it.
+
+    Parameters
+    ----------
+    pkg : str
+        The package to be updated.
+    rootname : str
+        Name of the root configuration directory.
+    overwrite : bool
+        Force updating the file if it already exists.
+
+    Returns
+    -------
+    updated : bool
+        If the profile was updated, `True`, otherwise `False`.
+
+    """
+    # local import to prevent using the logger before it is configured
+    from astropy.logger import log
+
+    cfgfn = Path(acc.get_config_filename(pkg, rootname=rootname))
+
+    # generate the default config template
+    template_content = io.StringIO()
+    generate_config(pkg, template_content)
+    template_content.seek(0)
+    template_content = template_content.read()
+
+    doupdate = True
+
+    # if the file already exists, check that it has not been modified
+    if cfgfn is not None and cfgfn.is_file():
+        with open(cfgfn, encoding="latin-1") as fd:
+            content = fd.read()
+
+        doupdate = acc.is_unedited_config_file(content, template_content)
+
+    if doupdate or overwrite:
+        with open(cfgfn, "w", encoding="latin-1") as fw:
+            fw.write(template_content)
+        log.info(f"The configuration file has been successfully written to {cfgfn}")
+        return True
+    elif not doupdate:
+        log.warning(
+            "The configuration file already exists and seems to "
+            "have been customized, so it has not been updated. "
+            "Use overwrite=True if you really want to update it."
+        )
+
+    return False

--- a/src/dysh/config/tests/test_config_core.py
+++ b/src/dysh/config/tests/test_config_core.py
@@ -1,0 +1,17 @@
+"""Tests for dysh.config.core"""
+
+import dysh.config as dc
+
+
+class TestConfig:
+
+    def test_get_config_dir_path(self):
+        path = dc.get_config_dir_path(rootname="test-dysh")
+        assert path.exists()
+
+    def test_create_config_file(self):
+        assert dc.create_config_file("dysh", rootname="test-dysh")
+        # Clean up.
+        path = dc.get_config_dir_path(rootname="test-dysh")
+        (path / "dysh.cfg").unlink()
+        path.rmdir()

--- a/src/dysh/fits/__init__.py
+++ b/src/dysh/fits/__init__.py
@@ -1,8 +1,41 @@
 """Classes and functions for importing SDFITS files"""
 
+# Configuration options follow.
+# These need to come after the global config variables, as some of the
+# submodules use them.
+from dysh import config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `dysh.fits`.
+    """
+
+    summary_max_rows = _config.ConfigItem(
+        1000,
+        "Maximum number of rows to be displayed by summary",
+    )
+
+
+conf = Conf()
+
 from dysh.fits.core import *
 from dysh.fits.gb20mfitsload import GB20MFITSLoad  # noqa:F401
 from dysh.fits.gbtfitsload import GBTFITSLoad  # noqa:F401
 from dysh.fits.gbtfitsload import GBTOffline  # noqa:F401
 from dysh.fits.gbtfitsload import GBTOnline  # noqa:F401
 from dysh.fits.sdfitsload import SDFITSLoad  # noqa:F401
+
+from . import core
+
+__all__ = (
+    ["Conf", "conf"]
+    + core.__all__
+    + [
+        "GB20MFITSLoad",
+        "GBTFITSLoad",
+        "GBTOffline",
+        "GBTOffline",
+        "SDFITSLoad",
+    ]
+)

--- a/src/dysh/fits/core.py
+++ b/src/dysh/fits/core.py
@@ -2,6 +2,8 @@
 Core functions for FITS/SDFITS
 """
 
+__all__ = ["default_sdfits_columns"]
+
 
 def default_sdfits_columns():
     """The default column names for GBT SDFITS.

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -37,11 +37,15 @@ from ..util import (
     uniq,
 )
 from ..util.files import dysh_data
+from ..util.selection import Flag, Selection
+from . import conf
 from .sdfitsload import SDFITSLoad
 
 # from GBT IDL users guide Table 6.7
 # @todo what about the Track/OnOffOn in e.g. AGBT15B_287_33.raw.vegas  (EDGE HI data)
 # _PROCEDURES = ["Track", "OnOff", "OffOn", "OffOnSameHA", "Nod", "SubBeamNod"]
+
+pd.set_option("display.max_rows", conf.summary_max_rows)
 
 
 class GBTFITSLoad(SDFITSLoad, HistoricalBase):

--- a/src/dysh/shell/shell.py
+++ b/src/dysh/shell/shell.py
@@ -16,7 +16,7 @@ from dysh.log import init_logging
 BANNER = f"""--------------------------------------------------------------------------
                          Welcome to Dysh v{__version__}
 
-    Example usage: https://dysh.readthedocs.io/en/latest/example.html
+    Example usage: https://dysh.readthedocs.io/
     Bug reports:    https://github.com/GreenBankObservatory/dysh/issues
 
     For help with a Dysh routine from the command line,
@@ -65,9 +65,17 @@ def init_shell(*ipython_args, colors=DEFAULT_COLORS, profile: Union[str, Path] =
     from astropy.io import fits
     from astropy.table import Table
 
-    from dysh.fits.gbtfitsload import GBTFITSLoad
+    from dysh.fits.gbtfitsload import GBTFITSLoad, GBTOffline, GBTOnline
 
-    user_ns = {"pd": pd, "np": np, "GBTFITSLoad": GBTFITSLoad, "Table": Table, "fits": fits}
+    user_ns = {
+        "pd": pd,
+        "np": np,
+        "GBTFITSLoad": GBTFITSLoad,
+        "GBTOnline": GBTOnline,
+        "GBTOffline": GBTOffline,
+        "Table": Table,
+        "fits": fits,
+    }
 
     c.BaseIPythonApplication.profile = profile
     c.InteractiveShell.colors = colors

--- a/src/dysh/shell/shell.py
+++ b/src/dysh/shell/shell.py
@@ -9,6 +9,7 @@ from traitlets.config import Config
 
 import dysh.fits
 from dysh import __version__
+from dysh.config import create_config_file
 from dysh.fits.sdfitsload import SDFITSLoad
 from dysh.log import init_logging
 
@@ -55,10 +56,17 @@ def parse_args():
     parser.add_argument("--log", help="Specify log path", type=Path)
     parser.add_argument("-q", "--quiet", help="Silence DEBUG- and INFO-level logs to stderr", action="store_true")
     parser.add_argument("--version", help="Print version and exit", action="store_true")
+    parser.add_argument("--skip-config", help="Skip creating a configuration file", action="store_true")
     return parser.parse_known_args()
 
 
-def init_shell(*ipython_args, colors=DEFAULT_COLORS, profile: Union[str, Path] = "DEFAULT_PROFILE", sdfits_files=None):
+def init_shell(
+    *ipython_args,
+    colors=DEFAULT_COLORS,
+    profile: Union[str, Path] = "DEFAULT_PROFILE",
+    sdfits_files=None,
+    skip_config=False,
+):
     c = Config()
     import numpy as np
     import pandas as pd
@@ -84,6 +92,8 @@ def init_shell(*ipython_args, colors=DEFAULT_COLORS, profile: Union[str, Path] =
     )
     if sdfits_files:
         user_ns["sdfits_files"] = sdfits_files
+    if not skip_config:
+        create_config_file("dysh", rootname="dysh")
     IPython.start_ipython(ipython_args, config=c, user_ns=user_ns)
 
 
@@ -106,7 +116,13 @@ def main():
         sys.exit(0)
     init_logging(verbosity=args.verbosity, path=args.log, quiet=args.quiet)
     sdfits_files = open_sdfits_files(args.paths, args.fits_loader)
-    init_shell(*remaining_args, colors=args.colors, profile=args.profile, sdfits_files=sdfits_files)
+    init_shell(
+        *remaining_args,
+        colors=args.colors,
+        profile=args.profile,
+        sdfits_files=sdfits_files,
+        skip_config=args.skip_config,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the use of a configuration file. The configuration file is created when launching `dysh`. By default the configuration file goes into: `$XDG_CONFIG_HOME/.dysh/config`
There is an option to skip the creation: `--skip-config`. 
When launching the shell, there is a INFO message stating that the configuration file was created (see below).


<img width="776" alt="Image showing the banner after launching the dysh shell" src="https://github.com/user-attachments/assets/9f98fd56-86d3-4fcc-b873-bff6c0a893cc" />
The location of the message could be improved.