### PR TITLE
Upgrade Python linting/formatting toolchain and fix linting errors

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# $ ruff format
+639cb06fcba5e0e16b752c41729bc4153dbbb8a6
+# $ ruff check --fix
+0bd816f70bd7f6abbc815c332fd2db3a6102dc08
+# $ ruff check --fix
+756e47ecf955a75190d822ae2a2cb88ca73467e8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
       - id: check-docstring-first
       - id: check-case-conflict # Check for files with names that would conflict on a case-insensitive filesystem
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.11.8
     hooks:
     - id: ruff-format
-    # - id: ruff
-    #   args: ['--fix', '--exit-non-zero-on-fix']
+    - id: ruff
+      args: ['--fix', '--exit-non-zero-on-fix']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,9 @@ repos:
           - '--fix=lf'
       - id: check-docstring-first
       - id: check-case-conflict # Check for files with names that would conflict on a case-insensitive filesystem
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
     hooks:
-      - id: isort
-        exclude: '(notebooks|attic|benchmark|testdata)/.*'
-  - repo: 'https://github.com/psf/black'
-    rev: 25.1.0
-    hooks:
-      - id: black
-        exclude: '(notebooks|attic|benchmark|testdata)/.*'
+    - id: ruff-format
+    # - id: ruff
+    #   args: ['--fix', '--exit-non-zero-on-fix']

--- a/benchmark/makeplots.py
+++ b/benchmark/makeplots.py
@@ -3,9 +3,7 @@ import argparse
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 from astropy.table import Table
-from matplotlib.ticker import FormatStrFormatter
 
 
 def add_patch(legend, fc, label):

--- a/benchmark/makeplots.py
+++ b/benchmark/makeplots.py
@@ -25,10 +25,10 @@ def add_patch(legend, fc, label):
 
 def lineplots(file):
     t = Table.read(file, format="ipac")
-    colors = ["red", "tan", "lime"]
+    colors = ["red", "tan", "lime"]  # noqa: F841
     df = t.to_pandas()  # .sort_values('N_rows')
     time_cols = ["Load", "Index", "Create_Obsblocks", "Baseline_1", "Baseline_2", "Baseline_3"]
-    tc = [s.replace("_", " ") for s in time_cols]
+    tc = [s.replace("_", " ") for s in time_cols]  # noqa: F841
     size_col = "Size"
     df[time_cols] /= 1000.0
     df[size_col] = np.rint(df[size_col]).astype(int)
@@ -126,7 +126,7 @@ def lineplots(file):
     for j in range(axindex, len(axf)):
         axf[j].axis("off")
     plt.subplots_adjust(wspace=0.35, hspace=0.25)
-    fontdict = {"size": 14, "fontweight": "bold"}
+    fontdict = {"size": 14, "fontweight": "bold"}  # noqa: F841
     fig.suptitle(args.title, size=14, weight="bold")
     if args.outfile:
         plt.savefig(args.outfile, dpi=300)
@@ -265,9 +265,9 @@ if __name__ == "__main__":
     if args.barplots:
         barplots(file=[args.file, args.file2])
 if False:
-    for c in ax.containers:
+    for c in ax.containers:  # noqa: F821
         # Optional: if the segment is small or 0, customize the labels
         labels = [np.rint(v.get_height()).astype(int) if v.get_height() > 0 else "" for v in c]
 
         # remove the labels parameter if it's not needed for customized labels
-        ax.bar_label(c, labels=labels, label_type="center")
+        ax.bar_label(c, labels=labels, label_type="center")  # noqa: F821

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,6 @@ import sys
 sys.path.insert(0, os.path.abspath("../../src"))
 sys.path.insert(0, os.path.abspath("."))
 
-import dysh
 from dysh import __version__
 
 # -- Project information -----------------------------------------------------

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -1,9 +1,9 @@
-import nbformat
-from nbclient import NotebookClient
-from glob import glob
 import os
 from pathlib import Path
+
+import nbformat
 import pytest
+from nbclient import NotebookClient
 
 
 def check_notebook_execution(notebook_file):

--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import pytest
 
+
 def check_notebook_execution(notebook_file):
     """Execute a given notebook and check for errors"""
 
@@ -14,9 +15,9 @@ def check_notebook_execution(notebook_file):
     notebook_dir = Path(notebook_file).parent.resolve()
 
     # Open the notebook
-    with open(notebook_file, 'r', encoding='utf-8') as f:
+    with open(notebook_file, "r", encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
-    
+
     # Try to execute the notebook
     try:
         # Change the current working directory to the notebook's directory
@@ -30,8 +31,8 @@ def check_notebook_execution(notebook_file):
         os.chdir(cwd)
         pytest.fail(f"Error executing notebook {notebook_file}: {e}")
 
-class TestNotebooks:
 
+class TestNotebooks:
     def setup_method(self):
         # Path to notebooks.
         self.notebook_dir = Path("notebooks/examples/")
@@ -40,27 +41,27 @@ class TestNotebooks:
 
     def test_notebooks_execution(self):
         """Test that each notebook runs without errors"""
-    
+
         for notebook_file in self.notebook_files:
             check_notebook_execution(notebook_file)
 
     def test_single_top_level_header(self):
         """Test that each notebook has exactly 1 top-level header"""
-        
+
         # Open each notebook
         for notebook_file in self.notebook_files:
-            with open(notebook_file, 'r', encoding='utf-8') as f:
+            with open(notebook_file, "r", encoding="utf-8") as f:
                 nb = nbformat.read(f, as_version=4)
-            
+
             top_level_headers = 0
-            
+
             # Search each markdown cell for top-level headers
             for cell in nb.cells:
-                if cell.cell_type == 'markdown':
+                if cell.cell_type == "markdown":
                     source = cell.source
-                    lines = source.split('\n')
+                    lines = source.split("\n")
                     for line in lines:
-                        if line.startswith('# '):
+                        if line.startswith("# "):
                             top_level_headers += 1
 
             assert top_level_headers == 1, f"Notebook {notebook_file} has {top_level_headers} top-level headers."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ nb = [
   "jupyter",
   "jupyterlab",
   "ipympl",
+  "jupyter-nbextensions-configurator>=0.6.4",
 ]
 all = ["dysh[nb]"]
 
@@ -50,11 +51,11 @@ dev = [
   "nbclient",
   "nbformat",
   "numpydoc",
-  "pip-tools",
   "pre-commit",
   "pytest",
   "pytest-cov",
   "pytest-xdist>=3.6.1",
+  "ruff",
   "sphinx",
   "sphinx-autobuild",
   "sphinx-book-theme",
@@ -120,7 +121,6 @@ exclude = [
 packages = ["src/dysh"]
 
 [tool.coverage.run]
-
 branch = true
 source = [
   "src/"
@@ -139,29 +139,14 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 
-[tool.isort]
-# See: https://pycqa.github.io/isort/docs/configuration/options/#example-pyprojecttoml
-profile = "black"
-combine_as_imports = true
-sections = [
-    "FUTURE",
-    "STDLIB",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER"
-]
-filter_files = true
-
-[tool.black]
-preview = true
-line-length = 120
-
 [tool.pyright]
 reportImplicitStringConcatenation = false
 
 [tool.ruff]
 line-length = 120
 src = ["src", "benchmark", "notebooks"]
+extend-exclude = ["attic", "notebooks/developer", "*.ipynb"]
+
 
 [tool.ruff.lint]
 select = [
@@ -175,17 +160,27 @@ select = [
   "RUF",  # https://beta.ruff.rs/docs/rules/#ruff-specific-rules-ruf
 ]
 fixable = ["ALL"]
-unfixable = ["B"]
 ignore = [
   "E741",  # ambiguous-variable-name
+  "PD901",
+  "RUF002", # ambiguous characters
+  "RUF052", # dummy var used
+  "PD015", # TODO: This really should be removed
+  "E501", # line too long TODO: This really should be removed
+  "NPY002",
+  "RUF012",
 ]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore  in all `__init__.py` files
-"__init__.py" = ["E402", "F405", "F403"]
-"**/{tests,docs,tools}/*" = ["E402", "B011"]
+"__init__.py" = ["ALL"]
+"**/{tests,docs,tools}/*" = ["E402", "B011", "B017"]
 # The stuff in the attic doesn't need to be linted at all
 "attic/**" = ["ALL"]
+
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -196,15 +191,6 @@ filterwarnings = [
 # Ignore tests that should only be run on the GBO network
 # By convention these should be named "test_{something}_gbo_only.py"
 addopts = "--ignore-glob='*_gbo_only.py'"
-
-[tool.pip-tools]
-src_files = ["pyproject.toml"]
-extra = ["nb", "dev"]
-resolver = "backtracking"
-output_file= "requirements.txt"
-no_strip_extras = true
-quiet = true
-no_emit_trusted_host = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/dysh/config/core.py
+++ b/src/dysh/config/core.py
@@ -140,7 +140,7 @@ def generate_config(pkgname="dysh", filename=None, verbose=False):
                     elif len(item.defaultvalue) == 1:
                         fp.write(f"# {item.name} = {item.defaultvalue[0]},\n\n")
                     else:
-                        fp.write(f"# {item.name} =" f' {",".join(map(str, item.defaultvalue))}\n\n')
+                        fp.write(f"# {item.name} = {','.join(map(str, item.defaultvalue))}\n\n")
                 else:
                     fp.write(f"# {item.name} = {item.defaultvalue}\n\n")
 

--- a/src/dysh/config/tests/test_config_core.py
+++ b/src/dysh/config/tests/test_config_core.py
@@ -13,14 +13,14 @@ class TestConfig:
     def test_create_config_file(self, tmp_path):
         with set_temp_config(tmp_path):
             assert dc.create_config_file("dysh", rootname="dysh-test")
-            path = dc.get_config_dir_path(rootname="dysh-test")
+            path = dc.get_config_dir_path(rootname="dysh-test")  # noqa: F841
         assert (tmp_path / "dysh-test/dysh.cfg").is_file()
 
     def test_create_config_file_overwrite(self, tmp_path):
         conf_str = """[fits]\n## Maximum number of rows to be displayed by summary\nsummary_max_rows = 2"""
         with set_temp_config(tmp_path):
             assert dc.create_config_file("dysh", rootname="dysh-test")
-            path = dc.get_config_dir_path(rootname="dysh-test")
+            path = dc.get_config_dir_path(rootname="dysh-test")  # noqa: F841
             with open(tmp_path / "dysh-test/dysh.cfg", "w") as log:
                 log.write(conf_str)
             with open(tmp_path / "dysh-test/dysh.cfg", "r") as log:

--- a/src/dysh/config/tests/test_config_core.py
+++ b/src/dysh/config/tests/test_config_core.py
@@ -6,7 +6,6 @@ import dysh.config as dc
 
 
 class TestConfig:
-
     def test_get_config_dir_path(self):
         path = dc.get_config_dir_path(rootname="dysh-test")
         assert path.exists()

--- a/src/dysh/coordinates/core.py
+++ b/src/dysh/coordinates/core.py
@@ -4,7 +4,6 @@ Core functions/classes for spatial and velocity coordinates and reference frames
 
 import warnings
 
-import astropy.constants as const
 import astropy.coordinates as coord
 import astropy.units as u
 import numpy as np

--- a/src/dysh/coordinates/core.py
+++ b/src/dysh/coordinates/core.py
@@ -207,13 +207,13 @@ def decode_veldef(veldef):
     try:
         velocity_convention = velocity_convention_dict[vconv]
     except KeyError:
-        raise KeyError(f"Velocity convention {vconv} not recognized.")
+        raise KeyError(f"Velocity convention {vconv} not recognized.")  # noqa: B904
 
     frame = veldef[4:]
     try:
         frame_type = frame_dict[frame]
     except KeyError:
-        raise KeyError(f"Velocity frame {frame} not recognized.")
+        raise KeyError(f"Velocity frame {frame} not recognized.")  # noqa: B904
 
     return velocity_convention, frame_type
 
@@ -318,7 +318,7 @@ def sanitize_skycoord(target):
             else:
                 pm_lon = target.pm_l_cosb
                 pm_lat = target.pm_b
-        except:
+        except:  # noqa: E722
             pm_lon = _PMZERORAD
             pm_lat = _PMZERORAD
         # print(
@@ -363,7 +363,7 @@ def sanitize_skycoord(target):
             radial_velocity=_rv,
         )
     else:
-        warnings.warn(f"Can't sanitize {target}")
+        warnings.warn(f"Can't sanitize {target}")  # noqa: B028
         return target
 
     _target.sanitized = True
@@ -405,7 +405,7 @@ def topocentric_velocity_to_frame(target, toframe, observer, obstime):
     # raise Exception("input frame must be ICRS")
     topocoord = observer.get_itrs(obstime=obstime)
     sc = coord.SpectralCoord(1 * u.Hz, observer=topocoord, target=_target)
-    sc2 = sc.with_observer_stationary_relative_to(toframe)
+    sc2 = sc.with_observer_stationary_relative_to(toframe)  # noqa: F841
     return sc.with_observer_stationary_relative_to(toframe).radial_velocity
 
 
@@ -688,7 +688,7 @@ class Observatory:
         return coord.EarthLocation.from_geodetic(longitude, latitude, height, ellipsoid)
 
 
-def eq2hor(lon, lat, frame, date_obs, unit="deg", location=GBT()):
+def eq2hor(lon, lat, frame, date_obs, unit="deg", location=GBT()):  # noqa: B008
     """
     Equatorial to horizontal coordinate conversion.
 
@@ -718,7 +718,7 @@ def eq2hor(lon, lat, frame, date_obs, unit="deg", location=GBT()):
     return lonlat.transform_to(coord.AltAz(location=location))
 
 
-def hor2eq(az, alt, frame, date_obs, unit="deg", location=GBT()):
+def hor2eq(az, alt, frame, date_obs, unit="deg", location=GBT()):  # noqa: B008
     """
     Horizontal to Equatorial coordinate conversion.
 

--- a/src/dysh/coordinates/tests/test_coordinates_core.py
+++ b/src/dysh/coordinates/tests/test_coordinates_core.py
@@ -49,7 +49,7 @@ class TestCore:
             ("radio", "galactic"),
             ("optical", "heliocentric"),
         ]
-        for i, j in zip(inputs, outputs):
+        for i, j in zip(inputs, outputs, strict=False):
             assert decode_veldef(i) == j
 
         # Now test that bad input raises an exception

--- a/src/dysh/fits/gb20mfitsload.py
+++ b/src/dysh/fits/gb20mfitsload.py
@@ -75,7 +75,7 @@ class GB20MFITSLoad(SDFITSLoad):
 
         self.selected_index = self._index.query(query)
         self.selected_data = self._bintable[0].data[list(self.selected_index.index)]
-        self.selected_index.reset_index(inplace=True, drop=True)
+        self.selected_index.reset_index(inplace=True, drop=True)  # noqa: PD002
 
     def _get_tsys_ps(self):
         """ """

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -40,7 +40,7 @@ from ..util import (
     uniq,
 )
 from ..util.files import dysh_data
-from ..util.selection import Flag, Selection
+from ..util.selection import Flag, Selection  # noqa: F811
 from . import conf
 from .sdfitsload import SDFITSLoad
 
@@ -267,7 +267,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         """
         return [p.as_posix() for p in self.files]
 
-    def index(self, hdu=None, bintable: int = None, fitsindex=None):
+    def index(self, hdu=None, bintable: int = None, fitsindex=None):  # noqa: RUF013
         """
         Return The index table
 
@@ -456,7 +456,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         _df["RESTFREQ"] = _df["RESTFREQ"] / 1.0e9  # convert to GHz
         _df["DOPFREQ"] = _df["DOPFREQ"] / 1.0e9  # convert to GHz
         if scan is not None:
-            if type(scan) == int:
+            if type(scan) == int:  # noqa: E721
                 scan = [scan]
             if len(scan) == 1:
                 scan = [scan[0], scan[0]]  # or should this be [scans[0],lastscan]?
@@ -494,8 +494,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             uf_int = select_from("PLNUM", uf_int["PLNUM"].iloc[0], uf_int)
             uf_int = select_from("IFNUM", uf_int["IFNUM"].iloc[0], uf_int)
             nint = len(set(uf_int["DATE-OBS"]))  # see gbtidl io/line_index__define.pro
-            obj = list(set(uf["OBJECT"]))[0]  # We assume they are all the same!
-            proc = list(set(uf["PROC"]))[0]  # We assume they are all the same!
+            obj = list(set(uf["OBJECT"]))[0]  # We assume they are all the same!  # noqa: RUF015
+            proc = list(set(uf["PROC"]))[0]  # We assume they are all the same!  # noqa: RUF015
             s2 = pd.Series(
                 [obj, proc, nIF, nPol, nint, nfeed],
                 name="uniqued data",
@@ -806,7 +806,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             # if it is list of lists, then it is upper lower inclusive
             dfs = selection.groupby(["FITSINDEX", "BINTABLE"])
             # the dict key for the groups is a tuple (fitsindex,bintable)
-            for i, ((fi, bi), g) in enumerate(dfs):
+            for i, ((fi, bi), g) in enumerate(dfs):  # noqa: B007
                 chan_mask = convert_array_to_mask(chan, self._sdf[fi].nchan(bi))
                 rows = g["ROW"].to_numpy()
                 logger.debug(f"Applying {chan} to {rows=}")
@@ -882,10 +882,10 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
 
         """
         if self._selection is None:
-            warnings.warn("Couldn't construct procedure string: index is not yet created.")
+            warnings.warn("Couldn't construct procedure string: index is not yet created.")  # noqa: B028
             return
         if "OBSMODE" not in self._index:
-            warnings.warn("Couldn't construct procedure string: OBSMODE is not in index.")
+            warnings.warn("Couldn't construct procedure string: OBSMODE is not in index.")  # noqa: B028
             return
         df = self["OBSMODE"].str.split(":", expand=True)
         for obj in [self._index, self._flag]:
@@ -906,7 +906,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         zero when the scan number changes.
         """
         if self._index is None:
-            warnings.warn("Couldn't construct integration number: index is not yet created.")
+            warnings.warn("Couldn't construct integration number: index is not yet created.")  # noqa: B028
             return
 
         # check it hasn't been constructed before.
@@ -914,7 +914,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             return
         # check that GBTIDL didn't write it out at some point.
         if "INT" in self._index:
-            self._index.rename(columns={"INT": "INTNUM"}, inplace=True)
+            self._index.rename(columns={"INT": "INTNUM"}, inplace=True)  # noqa: PD002
             for s in self._sdf:
                 s._rename_binary_table_column("int", "intnum")
             return
@@ -922,10 +922,10 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         intnumarray = np.empty(len(self._index), dtype=int)
         # Leverage pandas to group things by scan and observing time.
         dfs = self._index.groupby(["SCAN"])
-        for name, group in dfs:
+        for name, group in dfs:  # noqa: B007
             dfst = group.groupby("DATE-OBS")
             intnums = np.arange(0, len(dfst.groups))
-            for i, (n, g) in enumerate(dfst):
+            for i, (n, g) in enumerate(dfst):  # noqa: B007
                 idx = g.index
                 intnumarray[idx] = intnums[i]
         self._index["INTNUM"] = intnumarray
@@ -966,7 +966,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         scans = kwargs.get("SCAN", None)
         if scans is None:
             scans = uniq(_final["SCAN"])
-        elif type(scans) == int:
+        elif type(scans) == int:  # noqa: E721
             scans = list([scans])
         if "REF" in kwargs:
             scans.append(kwargs.pop("REF"))
@@ -1019,7 +1019,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         sig=None,
         cal=None,
         calibrate: bool = True,
-        bintable: int = None,
+        bintable: int = None,  # noqa: RUF013
         smoothref: int = 1,
         apply_flags: bool = True,
         **kwargs,
@@ -1127,11 +1127,11 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         ifnum: int,
         plnum: int,
         calibrate: bool = True,
-        bintable: int = None,
+        bintable: int = None,  # noqa: RUF013
         smoothref: int = 1,
         apply_flags: str = True,
         bunit: str = "ta",
-        zenith_opacity: float = None,
+        zenith_opacity: float = None,  # noqa: RUF013
         tsys=None,
         weights="tsys",
         **kwargs,
@@ -1201,7 +1201,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         ScanBase._check_bunit(bunit)
         if bunit.lower() != "ta" and zenith_opacity is None:
             raise ValueError("Can't scale the data without a valid zenith opacity")
-        if type(ref) != int and not isinstance(ref, Spectrum):
+        if type(ref) != int and not isinstance(ref, Spectrum):  # noqa: E721
             raise TypeError("Reference scan ('ref') must be either an integer scan number or a Spectrum object")
         if isinstance(scan, Spectrum):
             raise TypeError(
@@ -1209,7 +1209,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             )
 
         scanlist = {}
-        if type(scan) == int:
+        if type(scan) == int:  # noqa: E721
             scan = [scan]
         elif isinstance(scan, np.ndarray):
             scan = list(scan)
@@ -1223,7 +1223,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         )
         scanlist["ON"] = scans
         scanlist["OFF"] = [None] * len(scans)
-        if type(ref) == int:
+        if type(ref) == int:  # noqa: E721
             # make an average reference spectrum
             # @todo when tsys is addted to gettp, pass it on.
             refspec = self.gettp(
@@ -1305,11 +1305,11 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         ifnum: int,
         plnum: int,
         calibrate: bool = True,
-        bintable: int = None,
+        bintable: int = None,  # noqa: RUF013
         smoothref: int = 1,
         apply_flags: str = True,
         bunit: str = "ta",
-        zenith_opacity: float = None,
+        zenith_opacity: float = None,  # noqa: RUF013
         **kwargs,
     ) -> ScanBlock:
         """
@@ -1437,9 +1437,9 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         self,
         ifnum: int,
         plnum: int,
-        fdnum: int = None,
+        fdnum: int = None,  # noqa: RUF013
         calibrate: bool = True,
-        bintable: int = None,
+        bintable: int = None,  # noqa: RUF013
         smoothref: int = 1,
         apply_flags: bool = True,
         t_sys=None,
@@ -1632,7 +1632,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         fold=True,
         shift_method="fft",
         use_sig=True,
-        bintable: int = None,
+        bintable: int = None,  # noqa: RUF013
         smoothref: int = 1,
         apply_flags: bool = True,
         bunit="ta",
@@ -1788,7 +1788,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         timeaverage=True,
         polaverage=False,
         weights="tsys",
-        bintable: int = None,
+        bintable: int = None,  # noqa: RUF013
         smoothref: int = 1,
         apply_flags: bool = True,
         bunit="ta",
@@ -1908,7 +1908,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                     # Loop over cycles, calibrating each independently.
                     groups_zip = zip(ref_on_groups, sig_on_groups, ref_off_groups, sig_off_groups, strict=False)
 
-                    for i, (rgon, sgon, rgoff, sgoff) in enumerate(groups_zip):
+                    for i, (rgon, sgon, rgoff, sgoff) in enumerate(groups_zip):  # noqa: B007
                         # Do it the dysh way.
                         calrows = {"ON": rgon, "OFF": rgoff}
                         tprows = np.sort(np.hstack((rgon, rgoff)))
@@ -1963,7 +1963,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                     )
                     scanblock.append(sb)
         elif method == "scan":
-            for sdfi in range(len(self._sdf)):
+            for sdfi in range(len(self._sdf)):  # noqa: B007
                 # Process the whole scan as a single block.
                 # This is less accurate, but might be needed if
                 # the scan was aborted and there are not enough
@@ -2045,7 +2045,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             return s
         if lenprocset > 1:
             raise Exception(f"Found more than one PROCTYPE in the requested scans: {procset}")
-        proc = list(procset)[0]
+        proc = list(procset)[0]  # noqa: RUF015
         dfon = select_from(prockey, procvals["ON"], selection)
         dfoff = select_from(prockey, procvals["OFF"], selection)
         onscans = uniq(list(dfon["SCAN"]))  # wouldn't set() do this too?
@@ -2257,7 +2257,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
 
         radesys = {"AzEl": "AltAz", "HADec": "hadec", "Galactic": "galactic"}
 
-        warning_msg = (
+        warning_msg = (  # noqa: E731
             lambda scans,
             a,
             coord,
@@ -2268,7 +2268,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         low_el_mask = self["ELEVATIO"] < 5
         if low_el_mask.sum() > 0:
             low_el_scans = map(str, set(self._index.loc[low_el_mask, "SCAN"]))
-            warnings.warn(warning_msg(",".join(low_el_scans), "an", "elevation", "5 degrees"))
+            warnings.warn(warning_msg(",".join(low_el_scans), "an", "elevation", "5 degrees"))  # noqa: B028
 
         # Azimuth and elevation case.
         self._fix_column("RADESYS", radesys["AzEl"], {"CTYPE2": "AZ", "CTYPE3": "EL"})
@@ -2341,7 +2341,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         col_exists = len(set(self.columns).intersection(iset)) > 0
         # col_in_selection =
         if col_exists:
-            warnings.warn(f"Changing an existing SDFITS column {items}")
+            warnings.warn(f"Changing an existing SDFITS column {items}")  # noqa: B028
         # now deal with values as arrays
         is_array = False
         if isinstance(values, (Sequence, np.ndarray)) and not isinstance(values, str):
@@ -2363,7 +2363,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 start = start + s.total_rows
         selected_cols = self.selection.columns_selected()
         if items in selected_cols:
-            warnings.warn(
+            warnings.warn(  # noqa: B028
                 f"You have changed the metadata for a column that was previously used in a data selection [{items}]."
                 " You may wish to update the selection. "
             )
@@ -2512,7 +2512,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         if mask.sum() == 0.0:
             # Nothing to flag.
             return
-        flag_rows = np.where(mask == True)[0].tolist()
+        flag_rows = np.where(mask == True)[0].tolist()  # noqa: E712
         self.flag(row=flag_rows)
 
     def getbeam(self, debug=False):
@@ -2634,7 +2634,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         return tsys, g
 
     # @todo PJT feeds->fdnum and add other standard args
-    def vanecal(self, vane_sky, ifnum, plnum, feeds=range(16), mode=2, tcal=None, verbose=False, **kwargs):
+    def vanecal(self, vane_sky, ifnum, plnum, feeds=range(16), mode=2, tcal=None, verbose=False, **kwargs):  # noqa: B008
         """
         Return Tsys calibration values for all or selected beams of the Argus
         VANE/SKY calibration cycle.

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -1076,7 +1076,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 calrows["OFF"] = list(dfcalF["ROW"])
                 if len(calrows["ON"]) != len(calrows["OFF"]):
                     if len(calrows["ON"]) > 0:
-                        raise Exception(f'unbalanced calrows {len(calrows["ON"])} != {len(calrows["OFF"])}')
+                        raise Exception(f"unbalanced calrows {len(calrows['ON'])} != {len(calrows['OFF'])}")
                 # sig and cal are treated specially since
                 # they are not in kwargs and in SDFITS header
                 # they are not booleans but chars
@@ -2109,7 +2109,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             s["ON"] = sorted(set(sons))
             s["OFF"] = sorted(set(soffs))
             if len(s["ON"]) != len(s["OFF"]):
-                raise Exception(f'ON and OFF scan list lengths differ {len(s["ON"])} != {len(s["OFF"])}')
+                raise Exception(f"ON and OFF scan list lengths differ {len(s['ON'])} != {len(s['OFF'])}")
         return s
 
     def write(
@@ -2258,7 +2258,10 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         radesys = {"AzEl": "AltAz", "HADec": "hadec", "Galactic": "galactic"}
 
         warning_msg = (
-            lambda scans, a, coord, limit: f"""Scan(s) {scans} have {a} {coord} below {limit}. The GBT does not go that low. Any operations that rely on the sky coordinates are likely to be inaccurate (e.g., switching velocity frames)."""
+            lambda scans,
+            a,
+            coord,
+            limit: f"""Scan(s) {scans} have {a} {coord} below {limit}. The GBT does not go that low. Any operations that rely on the sky coordinates are likely to be inaccurate (e.g., switching velocity frames)."""
         )
 
         # Elevation below the GBT elevation limit (5 degrees) warning.

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -1247,7 +1247,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 continue
             rows = {}
 
-            for on, off in zip(scanlist["ON"], scanlist["OFF"]):
+            for on, off in zip(scanlist["ON"], scanlist["OFF"], strict=False):
                 _ondf = select_from("SCAN", on, _df)
                 _offdf = select_from("SCAN", off, _df)
                 if bintable is None:
@@ -1389,7 +1389,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 continue
             rows = {}
             # loop over scan pairs
-            for on, off in zip(scanlist["ON"], scanlist["OFF"]):
+            for on, off in zip(scanlist["ON"], scanlist["OFF"], strict=False):
                 _ondf = select_from("SCAN", on, _df)
                 _offdf = select_from("SCAN", off, _df)
                 # rows["ON"] = list(_ondf.index)
@@ -1567,7 +1567,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 rows = {}
                 # Loop over scan pairs.
                 c = 0
-                for on, off in zip(scanlist["ON"], scanlist["OFF"]):
+                for on, off in zip(scanlist["ON"], scanlist["OFF"], strict=False):
                     _ondf = select_from("SCAN", on, _df)
                     _offdf = select_from("SCAN", off, _df)
                     rows["ON"] = list(_ondf["ROW"])
@@ -1770,9 +1770,9 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             return
 
         self._fix_column("FDNUM", 1, {"FRONTEND": "Rcvr26_40", "PLNUM": 1})
-        logger.info(f"Fixing FDNUM mislabel for Rcvr26_40. FDNUM 0 changed to 1")
+        logger.info("Fixing FDNUM mislabel for Rcvr26_40. FDNUM 0 changed to 1")
         self._fix_column("FDNUM", 0, {"FRONTEND": "Rcvr26_40", "PLNUM": 0})
-        logger.info(f"Fixing FDNUM mislabel for Rcvr26_40. FDNUM 1 changed to 0")
+        logger.info("Fixing FDNUM mislabel for Rcvr26_40. FDNUM 1 changed to 0")
 
     # @todo sig/cal no longer needed?
     @log_call_to_result
@@ -1906,7 +1906,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                                 Try using method='scan'."""
                         raise ValueError(e)
                     # Loop over cycles, calibrating each independently.
-                    groups_zip = zip(ref_on_groups, sig_on_groups, ref_off_groups, sig_off_groups)
+                    groups_zip = zip(ref_on_groups, sig_on_groups, ref_off_groups, sig_off_groups, strict=False)
 
                     for i, (rgon, sgon, rgoff, sgoff) in enumerate(groups_zip):
                         # Do it the dysh way.

--- a/src/dysh/fits/sdfitsload.py
+++ b/src/dysh/fits/sdfitsload.py
@@ -147,7 +147,7 @@ class SDFITSLoad(object):
             df = df[df["BINTABLE"] == bintable]
         return df
 
-    def create_index(self, hdu=None, skipindex=["DATA", "FLAGS"]):
+    def create_index(self, hdu=None, skipindex=["DATA", "FLAGS"]):  # noqa: B006
         """
         Create the index of the SDFITS file.
 
@@ -495,16 +495,16 @@ class SDFITSLoad(object):
         else:
             bunit = None
             h = self.binheader[0]
-            for k, v, c in h.cards:
+            for k, v, c in h.cards:  # noqa: B007
                 if k == "BUNIT":
                     bunit = v
             ukey = None
-            for k, v, c in h.cards:  # loop over the (key,val,comment) for all cards in the header
+            for k, v, c in h.cards:  # loop over the (key,val,comment) for all cards in the header  # noqa: B007
                 if v == "DATA":
                     ukey = "TUNIT" + k[5:]
                     break
             if ukey is not None:  # ukey should almost never be "None" in standard SDFITS
-                for k, v, c in h.cards:
+                for k, v, c in h.cards:  # noqa: B007
                     if k == ukey:
                         if bunit != v:
                             logger.info(f"Found BUNIT={bunit}, now finding {ukey}={v}, using the latter")
@@ -683,7 +683,7 @@ class SDFITSLoad(object):
 
         """
         # ensure it is a list if int was given
-        if type(rows) == int:
+        if type(rows) == int:  # noqa: E721
             rows = [rows]
         # ensure rows are sorted
         rows.sort()
@@ -773,7 +773,7 @@ class SDFITSLoad(object):
         """
         ou = oldname.upper()
         nu = newname.upper()
-        self._index.rename(columns={ou: nu}, inplace=True)
+        self._index.rename(columns={ou: nu}, inplace=True)  # noqa: PD002
         self._rename_binary_table_column(ou, nu)
 
     def delete_column(self, column):
@@ -791,17 +791,17 @@ class SDFITSLoad(object):
         None.
 
         """
-        warnings.warn(f"Deleting column {column}. Cannot be undone!")
+        warnings.warn(f"Deleting column {column}. Cannot be undone!")  # noqa: B028
 
         if isinstance(column, str):
             cu = column.upper()
             if cu == "DATA":
                 raise Exception("You can't delete the DATA column. It's for your own good.")
-            self._index.drop(columns=cu, inplace=True)
+            self._index.drop(columns=cu, inplace=True)  # noqa: PD002
             self._delete_binary_table_column(column)
         elif isinstance(column, (Sequence, np.ndarray)):
             cu = [c.upper() for c in column]
-            self._index.drop(columns=cu, inplace=True)
+            self._index.drop(columns=cu, inplace=True)  # noqa: PD002
             for c in column:
                 self._delete_binary_table_column(c)
 
@@ -1076,7 +1076,7 @@ class SDFITSLoad(object):
         else:
             raise KeyError(f"Invalid key {items}. Keys must be str")
         if "DATA" in items:
-            warnings.warn("Beware: you are changing the DATA column.")
+            warnings.warn("Beware: you are changing the DATA column.")  # noqa: B028
         # warn if changing an existing column
         if isinstance(items, str):
             iset = set([items])
@@ -1084,11 +1084,11 @@ class SDFITSLoad(object):
             iset = set(items)
         col_exists = len(set(self.columns).intersection(iset)) > 0
         if col_exists and "DATA" not in items:
-            warnings.warn(f"Changing an existing SDFITS column {items}")
+            warnings.warn(f"Changing an existing SDFITS column {items}")  # noqa: B028
         try:
             self._update_column(d)
         except Exception as e:
-            raise Exception(f"Could not update SDFITS binary table for {items} because {e}")
+            raise Exception(f"Could not update SDFITS binary table for {items} because {e}")  # noqa: B904
         # only update the index if the binary table could be updated.
         # DATA is not in the index.
         if "DATA" not in items:

--- a/src/dysh/fits/tests/test_gb20mfitsload.py
+++ b/src/dysh/fits/tests/test_gb20mfitsload.py
@@ -38,4 +38,4 @@ class TestGB20mFITSload:
         """
         Test that we can use `getps`.
         """
-        spec = self.sdfits.getps(ifnum=0, plnum=0)
+        spec = self.sdfits.getps(ifnum=0, plnum=0)  # noqa: F841

--- a/src/dysh/fits/tests/test_gb20mfitsload.py
+++ b/src/dysh/fits/tests/test_gb20mfitsload.py
@@ -7,7 +7,6 @@ from dysh.util import get_project_testdata
 
 
 class TestGB20mFITSload:
-
     def setup_method(self):
         self.data_path = get_project_testdata() / "20m/Skynet_60476_DR21_118886_68343.cyb.fits"
         with pytest.warns(UserWarning):

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -1082,7 +1082,6 @@ class TestGBTFITSLoad:
                 assert b.data["FLAGS"].sum() == channels[i]
 
     def test_nums_are_ints(self):
-
         sdf_file = f"{self.data_dir}/TGBT21A_501_11/TGBT21A_501_11.raw.vegas.fits"
         sdf = gbtfitsload.GBTFITSLoad(sdf_file)
         with pytest.raises(ValueError):
@@ -1103,8 +1102,8 @@ class TestGBTFITSLoad:
 
         cols = ["PLNUM", "FDNUM"]
         assert sdf1[cols].all(axis=1).sum() == 0  # PLNUM=0 corresponds to FDNUM=1, so this should be zero.
-        assert sdf2[cols].all(axis=1).sum() == sdf2._sdf[0].nintegrations(
-            0
+        assert (
+            sdf2[cols].all(axis=1).sum() == sdf2._sdf[0].nintegrations(0)
         )  # Only FDNUM=1 will be True, so this returns half the total number of rows, which is equal to the number of integrations.
 
     def test_getps_ka(self):

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -83,7 +83,7 @@ class TestGBTFITSLoad:
         spec2 = sdf.getspec(0, setmask=True)
         assert any(spec.mask != spec2.mask)
         assert all(spec2.mask[0:101])
-        assert all(spec2.mask[102:] == False)
+        assert all(spec2.mask[102:] == False)  # noqa: E712
 
     def test_getps_single_int(self):
         """
@@ -284,8 +284,8 @@ class TestGBTFITSLoad:
             7: {"SCAN": 6, "IFNUM": 2, "PLNUM": 0, "CAL": False, "SIG": False},
             8: {"SCAN": 6, "IFNUM": 2, "PLNUM": 0, "CAL": False, "SIG": True},
         }
-        for k, v in tests.items():
-            if v["SIG"] == False:
+        for k, v in tests.items():  # noqa: B007
+            if v["SIG"] == False:  # noqa: E712
                 with pytest.raises(Exception):
                     tps = sdf.gettp(
                         scan=v["SCAN"], ifnum=v["IFNUM"], plnum=v["PLNUM"], fdnum=0, cal=v["CAL"], sig=v["SIG"]
@@ -697,7 +697,7 @@ class TestGBTFITSLoad:
         # Not this part of the test, but just to make sure.
         assert np.all(sdf["RADESYS"] == "AltAz")
         # Test that we can create a `Spectrum` object.
-        tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)
+        tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)  # noqa: F841
 
     @pytest.mark.filterwarnings("ignore:Changing an existing SDFITS column")
     def test_hadec_coords(self, tmp_path):
@@ -724,7 +724,7 @@ class TestGBTFITSLoad:
         # Not this part of the test, but just to make sure.
         assert np.all(sdf["RADESYS"] == "hadec")
         # Test that we can create a `Spectrum` object.
-        tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)
+        tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)  # noqa: F841
 
     @pytest.mark.filterwarnings("ignore:Changing an existing SDFITS column")
     def test_galactic_coords(self, tmp_path):
@@ -752,7 +752,7 @@ class TestGBTFITSLoad:
         # Not this part of the test, but just to make sure.
         assert np.all(sdf["RADESYS"] == "galactic")
         # Test that we can create a `Spectrum` object.
-        tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)
+        tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)  # noqa: F841
 
     def test_add_history_comments(self):
         fits_path = util.get_project_testdata() / "AGBT18B_354_03/AGBT18B_354_03.raw.vegas"
@@ -786,7 +786,7 @@ class TestGBTFITSLoad:
             print("Windows seems to lock the file, can't remover or overwite")
         else:
             shutil.copyfile(f2, o1)
-            s = sdf.summary()
+            s = sdf.summary()  # noqa: F841
             n = len(sdf._index)
             assert n == 8
 
@@ -842,13 +842,13 @@ class TestGBTFITSLoad:
         sdf = gbtfitsload.GBTFITSLoad(fits_path)
         # The data should not be flagged, as the flags are only for intnum=arange(43,52)
         ps = sdf.getps(scan=19, plnum=0, ifnum=0, fdnum=0, apply_flags=True).timeaverage()
-        assert np.all(ps.mask == False)
+        assert np.all(ps.mask == False)  # noqa: E712
         # The data should be flagged for these integrations.
         ps = sdf.getps(
             scan=19, plnum=0, ifnum=0, fdnum=0, apply_flags=True, intnum=[i for i in range(43, 52)]
         ).timeaverage()
-        assert np.all(ps.mask[2299:] == True)
-        assert np.all(ps.mask[:2299] == False)
+        assert np.all(ps.mask[2299:] == True)  # noqa: E712
+        assert np.all(ps.mask[:2299] == False)  # noqa: E712
 
     def test_rawspectrum(self):
         """regression test for issue 442"""
@@ -1033,7 +1033,7 @@ class TestGBTFITSLoad:
         qd_el = sdf["QD_EL"].to_numpy()
         qd_el[10] += 100
         sdf.qd_flag()
-        assert np.all(sdf.flags.final.index.values == 10)
+        assert np.all(sdf.flags.final.index.values == 10)  # noqa: PD011
         sdf.flags.clear()
 
         qd_el[11:15] += 100
@@ -1089,7 +1089,7 @@ class TestGBTFITSLoad:
         with pytest.raises(ValueError):
             sba = sdf.getps(scan=152, bunit="ta*", zenith_opacity=0.05, ifnum=0, plnum=0, fdnum=[1, 0])
         with pytest.raises(ValueError):
-            sba = sdf.getps(scan=152, bunit="ta*", zenith_opacity=0.05, ifnum=0, plnum=[0, 1], fdnum=0)
+            sba = sdf.getps(scan=152, bunit="ta*", zenith_opacity=0.05, ifnum=0, plnum=[0, 1], fdnum=0)  # noqa: F841
 
     def test_fix_ka(self):
         """
@@ -1224,4 +1224,4 @@ class TestGBTFITSLoad:
         with pytest.raises(TypeError):
             sb = sdf.getsigref(scan=x, ref=52, fdnum=0, ifnum=0, plnum=0)
         with pytest.raises(TypeError):
-            sb = sdf.getsigref(scan=51, ref=x.data, fdnum=0, ifnum=0, plnum=0)
+            sb = sdf.getsigref(scan=51, ref=x.data, fdnum=0, ifnum=0, plnum=0)  # noqa: F841

--- a/src/dysh/fits/tests/test_sdfitsload.py
+++ b/src/dysh/fits/tests/test_sdfitsload.py
@@ -54,7 +54,7 @@ class TestSDFITSLoad:
         """
         Test basic filename
         """
-        filename = "TGBT21A_501_11.raw.vegas.fits"
+        filename = "TGBT21A_501_11.raw.vegas.fits"  # noqa: F841
         fnm = self._file_list[0]  # note fnm is a string
         sdf = SDFITSLoad(fnm)
         assert fnm == sdf.filename
@@ -102,7 +102,7 @@ class TestSDFITSLoad:
         with pytest.warns(UserWarning):
             g["FREQRES"] = 1500.0  # Hz
         # test that the selection (index) was set
-        assert list(set(g["FREQRES"]))[0] == 1500
+        assert list(set(g["FREQRES"]))[0] == 1500  # noqa: RUF015
         # test that the BinTableHDU data was set
         assert np.all(g._bintable[0].data["FREQRES"] == 1500.0)
         # rows of a column to different values

--- a/src/dysh/log.py
+++ b/src/dysh/log.py
@@ -193,15 +193,15 @@ def log_function_call(log_level: str = "info"):
         try:
             ilog_level = logging._nameToLevel[log_level.upper()]
         except KeyError:
-            raise Exception(f"Log level {log_level} unrecognized. Must be one of {list(logging._nameToLevel.keys())}.")
+            raise Exception(f"Log level {log_level} unrecognized. Must be one of {list(logging._nameToLevel.keys())}.")  # noqa: B904
 
         @wraps(func)
         def func_wrapper(*args, **kwargs):
             try:
                 result = func(*args, **kwargs)
-            except:  # remove the wrapper from the stack trace
+            except:  # remove the wrapper from the stack trace  # noqa: E722
                 tp, exc, tb = sys.exc_info()
-                raise tp(exc).with_traceback(tb.tb_next)
+                raise tp(exc).with_traceback(tb.tb_next)  # noqa: B904
             # Log the function name and arguments
             sig = inspect.signature(func)
             logmsg = f"DYSH v{dysh_version} : {func.__module__}"
@@ -279,16 +279,16 @@ def log_call_to_result(func: Callable):
         if self is None:
             try:
                 result = func(*args, **kwargs)
-            except:  # remove the wrapper from the stack trace
+            except:  # remove the wrapper from the stack trace  # noqa: E722
                 # @todo this no longer works under python >3.9
                 tp, exc, tb = sys.exc_info()
-                raise tp(exc).with_traceback(tb.tb_next)
+                raise tp(exc).with_traceback(tb.tb_next)  # noqa: B904
         else:
             try:
                 result = func(self, *args, **kwargs)
-            except:  # remove the wrapper from the stack trace
+            except:  # remove the wrapper from the stack trace  # noqa: E722
                 tp, exc, tb = sys.exc_info()
-                raise tp(exc).with_traceback(tb.tb_next)
+                raise tp(exc).with_traceback(tb.tb_next)  # noqa: B904
         resultname = result.__class__.__name__
         if hasattr(result, "_history"):
             sig = inspect.signature(func)
@@ -344,15 +344,15 @@ def log_call_to_history(func: Callable):
             # could put this try around the whole thing but then it would catch exceptions from the wrapper itself
             try:
                 result = func(*args, **kwargs)
-            except:  # remove the wrapper from the stack trace
+            except:  # remove the wrapper from the stack trace  # noqa: E722
                 tp, exc, tb = sys.exc_info()
-                raise tp(exc).with_traceback(tb.tb_next)
+                raise tp(exc).with_traceback(tb.tb_next)  # noqa: B904
         else:  # it's a class instance
             try:
                 result = func(self, *args, **kwargs)
-            except:  # remove the wrapper from the stack trace
+            except:  # remove the wrapper from the stack trace  # noqa: E722
                 tp, exc, tb = sys.exc_info()
-                raise tp(exc).with_traceback(tb.tb_next)
+                raise tp(exc).with_traceback(tb.tb_next)  # noqa: B904
             classname = self.__class__.__name__
             if hasattr(self, "_history"):
                 sig = inspect.signature(func)
@@ -387,7 +387,7 @@ def log_call_to_history(func: Callable):
 StrList = NewType("Strlist", list[str])
 
 
-class HistoricalBase(ABC):
+class HistoricalBase(ABC):  # noqa: B024
     """Abstract base class to manage history and comments metadata."""
 
     def __init__(self):

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -171,7 +171,7 @@ class SpectrumPlot:
         xunit = this_plot_kwargs["xaxis_unit"]
         yunit = this_plot_kwargs["yaxis_unit"]
         if xunit is None:
-            xunit = str(sa.unit)
+            xunit = str(sa.unit)  # noqa: F821
         if "vel_frame" not in this_plot_kwargs:
             if u.Unit(xunit).is_equivalent("km/s") and "VELDEF" in s.meta:
                 # If the user specified velocity units, default to
@@ -295,7 +295,7 @@ class SpectrumPlot:
             and other keyword=value arguments
         """
         title = kwargs.get("title", None)
-        xlabel = kwargs.get("xlabel", None)
+        xlabel = kwargs.get("xlabel", None)  # noqa: F841
         ylabel = kwargs.get("ylabel", None)
         if title is not None:
             self._title = title
@@ -461,7 +461,7 @@ class InteractiveSpanSelector:
         self.colors = {
             "edge": (0, 0, 0, 1),
             "face": (0, 0, 0, 0.3),
-            "edge_selected": plt.matplotlib.colors.to_rgb("#6c3483") + (1.0,),
+            "edge_selected": plt.matplotlib.colors.to_rgb("#6c3483") + (1.0,),  # noqa: RUF005
         }
 
         # SpanSelector for creating new regions.
@@ -570,7 +570,7 @@ class InteractiveSpanSelector:
     def clear_region(self, event=None):
         if not self.active_patch:
             return
-        idx = self.regions.index(self.active_patch)
+        idx = self.regions.index(self.active_patch)  # noqa: F841
         self.regions.remove(self.active_patch)
         self.active_patch.remove()
         self.active_patch = None

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -376,10 +376,10 @@ class SpectrumPlot:
 
         # col 5
         self._axis.annotate(
-            f"Tsys   :  {np.around(s.meta['MEANTSYS'],2)}", (hcoords[4], vcoords[0]), xycoords=xyc, size=fsize_small
+            f"Tsys   :  {np.around(s.meta['MEANTSYS'], 2)}", (hcoords[4], vcoords[0]), xycoords=xyc, size=fsize_small
         )
         self._axis.annotate(
-            f"Tcal   :  {np.around(s.meta['TCAL'],2)}", (hcoords[4], vcoords[1]), xycoords=xyc, size=fsize_small
+            f"Tcal   :  {np.around(s.meta['TCAL'], 2)}", (hcoords[4], vcoords[1]), xycoords=xyc, size=fsize_small
         )
         self._axis.annotate(f"{s.meta['PROC']}", (hcoords[4], vcoords[2]), xycoords=xyc, size=fsize_small)
 

--- a/src/dysh/plot/tests/test_specplot.py
+++ b/src/dysh/plot/tests/test_specplot.py
@@ -1,7 +1,5 @@
 """Tests for specplot."""
 
-from pathlib import Path
-
 from dysh.fits import GBTFITSLoad
 from dysh.util import get_project_testdata
 

--- a/src/dysh/plot/vegasplot.py
+++ b/src/dysh/plot/vegasplot.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.ma as ma
 
 
 def plot_vegas(sdf, scans, title=None, tsys=False, inverse=False, edge=50, ylim=None):

--- a/src/dysh/shell/shell.py
+++ b/src/dysh/shell/shell.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import sys
 from pathlib import Path
 from typing import List, Union

--- a/src/dysh/shell/shell.py
+++ b/src/dysh/shell/shell.py
@@ -88,7 +88,7 @@ def init_shell(
     c.BaseIPythonApplication.profile = profile
     c.InteractiveShell.colors = colors
     c.InteractiveShell.banner2 = BANNER.format(
-        user_ns_str="\n".join(f"{' '*8}{k} (from {v.__name__})" for k, v in user_ns.items())
+        user_ns_str="\n".join(f"{' ' * 8}{k} (from {v.__name__})" for k, v in user_ns.items())
     )
     if sdfits_files:
         user_ns["sdfits_files"] = sdfits_files

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -560,7 +560,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
     }
     model = minimum_string_match(kwargs_opts["model"], list(available_models.keys()))
     if model == None:
-        raise ValueError(f'Unrecognized input model {kwargs["model"]}. Must be one of {list(available_models.keys())}')
+        raise ValueError(f"Unrecognized input model {kwargs['model']}. Must be one of {list(available_models.keys())}")
     sa_min = spectrum.spectral_axis.min().value
     sa_max = spectrum.spectral_axis.max().value
     selected_model = available_models[model](degree=order, domain=(sa_max, sa_min))
@@ -568,7 +568,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
     _valid_exclude_actions = ["replace", "append", None]
     if kwargs_opts["exclude_action"] not in _valid_exclude_actions:
         raise ValueError(
-            f'Unrecognized exclude region action {kwargs["exclude_region"]}. Must be one of {_valid_exclude_actions}'
+            f"Unrecognized exclude region action {kwargs['exclude_region']}. Must be one of {_valid_exclude_actions}"
         )
     fitter = kwargs_opts["fitter"]
     # print(f"MODEL {model} FITTER {fitter}")

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -275,7 +275,7 @@ def exclude_to_spectral_region(exclude, refspec, fix_exclude=True):
         A `~specutils.SpectralRegion` corresponding to `exclude`.
     """
 
-    p = refspec
+    p = refspec  # noqa: F841
     sa = refspec.spectral_axis
     lastchan = len(sa) - 1
 
@@ -308,7 +308,7 @@ def exclude_to_spectral_region(exclude, refspec, fix_exclude=True):
                     if mask.sum() > 0:
                         msg = f"Setting upper limit to {lastchan}."
                         exclude[exclude > len(sa)] = lastchan
-                        warnings.warn(msg)
+                        warnings.warn(msg)  # noqa: B028
                 # If the spectral_axis is decreasing, flip it.
                 sr = SpectralRegion(sa[exclude][:, ::o])
 
@@ -558,7 +558,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
         "polynomial": Polynomial1D,
     }
     model = minimum_string_match(kwargs_opts["model"], list(available_models.keys()))
-    if model == None:
+    if model == None:  # noqa: E711
         raise ValueError(f"Unrecognized input model {kwargs['model']}. Must be one of {list(available_models.keys())}")
     sa_min = spectrum.spectral_axis.min().value
     sa_max = spectrum.spectral_axis.max().value
@@ -737,7 +737,7 @@ def tsys_weight(exposure, delta_freq, tsys):
     # precision over the calculation used by GBTIDL:
     # weight = abs(delta_freq) * exposure / tsys**2.
     weight = abs(delta_freq) * exposure * np.power(tsys, -2.0)
-    if type(weight) == u.Quantity:
+    if type(weight) == u.Quantity:  # noqa: E721
         return weight.value.astype(np.float64)
     else:
         return weight.astype(np.float64)
@@ -977,7 +977,7 @@ def smooth(data, method="hanning", width=1, kernel=None, show=False):
         "gaussian": Gaussian1DKernel,
     }
     method = minimum_string_match(method, list(available_methods.keys()))
-    if method == None:
+    if method == None:  # noqa: E711
         raise ValueError(f"Unrecognized input method {method}. Must be one of {list(available_methods.keys())}")
     kernel = available_methods[method](width)
     if show:
@@ -986,7 +986,7 @@ def smooth(data, method="hanning", width=1, kernel=None, show=False):
     if hasattr(data, "mask"):
         mask = data.mask
     else:
-        mask = None
+        mask = None  # noqa: F841
     new_data = convolve(data, kernel, boundary="extend")  # , nan_treatment="fill", fill_value=np.nan, mask=mask)
     return new_data
 

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -22,7 +22,6 @@ from specutils.fitting import fit_continuum
 from specutils.fitting.fitmodels import _strip_units_from_model
 from specutils.utils import QuantityModel
 
-from ..coordinates import veltofreq
 from ..log import logger
 from ..util import minimum_string_match, powerof2
 
@@ -178,7 +177,7 @@ def sort_spectral_region(spectral_region):
     unit = spectral_region.lower.unit
     bound_list = np.sort([srb.value for sr in spectral_region.subregions for srb in sr]) * unit
     it = iter(bound_list)
-    sorted_spectral_region = SpectralRegion(list(zip(it, it)))
+    sorted_spectral_region = SpectralRegion(list(zip(it, it, strict=False)))
 
     return sorted_spectral_region
 
@@ -296,7 +295,7 @@ def exclude_to_spectral_region(exclude, refspec, fix_exclude=True):
             # took a list argument, we wouldn't have to do this.
             if type(exclude[0]) is not tuple:
                 it = iter(exclude)
-                exclude = list(zip(it, it))
+                exclude = list(zip(it, it, strict=False))
             try:
                 sr = SpectralRegion(exclude)
                 # The above will error if the elements are not quantities.
@@ -351,7 +350,7 @@ def spectral_region_to_unit(spectral_region, refspec, unit=None, append_doppler=
     lb = qt["lower_bound"].to(unit, equivalencies=refspec.equivalencies)
     ub = qt["upper_bound"].to(unit, equivalencies=refspec.equivalencies)
 
-    return SpectralRegion(list(zip(lb, ub)))
+    return SpectralRegion(list(zip(lb, ub, strict=False)))
 
 
 def append_doppler_to_spectral_region_qtable(qtable, refspec):

--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -728,7 +728,7 @@ class ScanBlock(UserList, HistoricalBase, SpectralAverageMixin):
         if len(bunit) > 1:
             logger.warning(f"The Scans in this ScanBlock have differing brightness units {bunit}")
             return list(bunit)
-        return list(bunit)[0]
+        return list(bunit)[0]  # noqa: RUF015
 
     def write(self, fileobj, output_verify="exception", overwrite=False, checksum=False):
         """
@@ -968,7 +968,7 @@ class TPScan(ScanBase):
             self._calibrated = (0.5 * (self._refcalon + self._refcaloff)).astype(float)
         elif self.calstate:
             self._calibrated = self._refcalon.astype(float)
-        elif self.calstate == False:
+        elif self.calstate == False:  # noqa: E712
             self._calibrated = self._refcaloff.astype(float)
         else:
             raise Exception(f"Unrecognized cal state {self.calstate}")  # should never happen
@@ -1028,7 +1028,7 @@ class TPScan(ScanBase):
         elif self.calstate:
             exp_ref_on = self._sdfits.index(bintable=self._bintable_index).iloc[self._refonrows]["EXPOSURE"].to_numpy()
             exp_ref_off = 0
-        elif self.calstate == False:
+        elif self.calstate == False:  # noqa: E712
             exp_ref_on = 0
             exp_ref_off = (
                 self._sdfits.index(bintable=self._bintable_index).iloc[self._refoffrows]["EXPOSURE"].to_numpy()
@@ -1044,7 +1044,7 @@ class TPScan(ScanBase):
             delta_freq = 0.5 * (df_ref_on + df_ref_off)
         elif self.calstate:
             delta_freq = df_ref_on
-        elif self.calstate == False:
+        elif self.calstate == False:  # noqa: E712
             delta_freq = df_ref_off
         self._delta_freq = delta_freq
 

--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -170,7 +170,6 @@ class ScanBase(HistoricalBase, SpectralAverageMixin):
             )
 
     def _finish_initialization(self, calibrate, calibrate_kwargs, meta_rows, bunit, zenith_opacity):
-
         if len(meta_rows) == 0:
             raise Exception(
                 f"In Scan {self.scan}, no data left to calibrate. Check blank integrations, flags, and selection."
@@ -476,9 +475,9 @@ class ScanBase(HistoricalBase, SpectralAverageMixin):
         self._meta = df.to_dict("records")  # returns dict(s) with key = row number.
         for i in range(len(self._meta)):
             if "CUNIT1" not in self._meta[i]:
-                self._meta[i][
-                    "CUNIT1"
-                ] = "Hz"  # @todo this is in gbtfits.hdu[0].header['TUNIT11'] but is it always TUNIT11?
+                self._meta[i]["CUNIT1"] = (
+                    "Hz"  # @todo this is in gbtfits.hdu[0].header['TUNIT11'] but is it always TUNIT11?
+                )
             self._meta[i]["CUNIT2"] = "deg"  # is this always true?
             self._meta[i]["CUNIT3"] = "deg"  # is this always true?
             restfrq = self._meta[i]["RESTFREQ"]
@@ -1784,8 +1783,8 @@ class FSScan(ScanBase):
         """
         # @todo upgrade fold from kwarg to arg
         if self._debug:
-            logger.debug(f'FOLD={kwargs["fold"]}')
-            logger.debug(f'METHOD={kwargs["shift_method"]}')
+            logger.debug(f"FOLD={kwargs['fold']}")
+            logger.debug(f"METHOD={kwargs['shift_method']}")
         if self._calibrated is not None:
             logger.warning(f"Scan {self.scan} was previously calibrated. Calibrating again.")
 

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -1109,7 +1109,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         # RADECSYS is also a valid column name. See issue #287
         # https://github.com/GreenBankObservatory/dysh/issues/287
-        if "RADECSYS" in _meta.keys() and not "RADESYS" in _meta.keys():
+        if "RADECSYS" in _meta.keys() and "RADESYS" not in _meta.keys():
             _meta["RADESYS"] = deepcopy(_meta["RADECSYS"])
             del _meta["RADECSYS"]
 

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -215,9 +215,9 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         # `include` and `exclude` are mutually exclusive, but we allow `include`
         # if `include` is used, transform it to `exclude`.
-        if include != None:
-            if exclude != None:
-                logger.info(f"Warning: ignoring exclude={exclude}")
+        if include != None:  # noqa: E711
+            if exclude != None:  # noqa: E711
+                logger.info(f"Warning: ignoring exclude={exclude}")  # noqa: F821
             exclude = core.include_to_exclude_spectral_region(include, self)
 
         self._baseline_model = baseline(self, degree, exclude, **kwargs)
@@ -239,7 +239,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
             return
         if self._subtracted:
             if self._normalized:
-                warnings.warn("Cannot undo previously normalized baseline subtraction")
+                warnings.warn("Cannot undo previously normalized baseline subtraction")  # noqa: B028
                 return
             s = self.add(self._baseline_model(self.spectral_axis))
             self._data = s._data
@@ -446,7 +446,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         s : `Spectrum`
             The new, possibly decimated, convolved `Spectrum`.
         """
-        nchan = len(self._data)
+        nchan = len(self._data)  # noqa: F841
         # decimate = int(decimate) # Should we change this value and tell the user, or just error out?
         # For now, we'll error out if decimate is not an integer..
 
@@ -456,7 +456,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         # @todo  see also core.smooth() for valid_methods
         valid_methods = ["hanning", "boxcar", "gaussian"]
         this_method = minimum_string_match(method, valid_methods)
-        if this_method == None:
+        if this_method == None:  # noqa: E711
             raise Exception(f"smooth({method}): valid methods are {valid_methods}")
 
         if not float(decimate).is_integer():
@@ -1162,12 +1162,12 @@ class Spectrum(Spectrum1D, HistoricalBase):
                         _meta["SITELONG"], _meta["SITELAT"], _meta["SITEELEV"]
                     )
                 except KeyError as ke:
-                    raise Exception(f"Not enough info to create observer_location: {ke}")
+                    raise Exception(f"Not enough info to create observer_location: {ke}")  # noqa: B904
             obsitrs = SpectralCoord._validate_coordinate(
                 attach_zero_velocities(observer_location.get_itrs(obstime=obstime))
             )
         else:
-            warnings.warn(
+            warnings.warn(  # noqa: B028
                 "'meta' does not contain DATE-OBS or MJD-OBS. Spectrum won't be convertible to certain coordinate"
                 " frames"
             )
@@ -1498,11 +1498,11 @@ def _read_table(fileobj, format, **kwargs):
         # parse the 3rd line column names, We only care about the ferquency axis
         h3 = df[df.columns[0]][1].split()
         units, vd = h3[0].split("-")
-        spectral_axis = spectral_axis.values * u.Unit(units)
+        spectral_axis = spectral_axis.values * u.Unit(units)  # noqa: PD011
         meta["VELDEF"] = velocity_convention + "-" + vd
         meta["POL"] = h3[1]
 
-        s = Spectrum(flux=flux.values * fu, spectral_axis=spectral_axis, meta=meta)
+        s = Spectrum(flux=flux.values * fu, spectral_axis=spectral_axis, meta=meta)  # noqa: PD011
         return s
 
     t = Table.read(fileobj, format=format, **kwargs)

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -492,7 +492,6 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         # Now decimate if needed.
         if decimate >= 0:
-
             if decimate == 0:
                 # Take the default decimation by `width`.
                 decimate = int(abs(width))
@@ -1294,7 +1293,6 @@ class Spectrum(Spectrum1D, HistoricalBase):
         return deepcopy(operand)
 
     def __getitem__(self, item):
-
         def q2idx(q, wcs, spectral_axis, coo, sto):
             """Quantity to index."""
             if "velocity" in u.get_physical_type(q):

--- a/src/dysh/spectra/tests/test_doppler_conventions.py
+++ b/src/dysh/spectra/tests/test_doppler_conventions.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
 from gzip import GzipFile
 
 import astropy.units as u
 import numpy as np
-import pytest
 
 from dysh.fits import gbtfitsload
 

--- a/src/dysh/spectra/tests/test_scan.py
+++ b/src/dysh/spectra/tests/test_scan.py
@@ -114,10 +114,10 @@ class TestPSScan:
         gbtidl_post = hdu[1].data["DATA"][0]
         hdu.close()
         hdu = fits.open(gbtidl_modelfile)
-        gbtidl_bline_model = hdu[1].data["DATA"][0]
+        gbtidl_bline_model = hdu[1].data["DATA"][0]  # noqa: F841
         hdu.close()
 
-        diff = psscan - gbtidl_post
+        diff = psscan - gbtidl_post  # noqa: F841
 
         # check that the spectra are the same but this won't pass right now
         # what is the tolerance for not passing?
@@ -136,7 +136,7 @@ class TestPSScan:
         ta1 = ps_sb.timeaverage()
         if False:
             # This should not raise any errors.
-            ta2 = ps_sb.timeaverage(None)
+            ta2 = ps_sb.timeaverage(None)  # noqa: F841
             # Check if the time average is all NaNs.
             all_nan = np.isnan(ta1.flux.value).sum() == len(ta1.flux)
             assert ~all_nan
@@ -199,7 +199,7 @@ class TestSubBeamNod:
         # the difference at the ~0.06 K level
         assert np.nanmedian(ratio) <= 0.998
         # make sure call to timeaverage functions
-        xx = sbn.timeaverage()
+        xx = sbn.timeaverage()  # noqa: F841
 
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     def test_synth_spectra(self, data_dir):
@@ -477,4 +477,4 @@ class TestScanBlock:
         testfile = o / "test_scanblock_write.fits"
         sb.write(fileobj=testfile, overwrite=True)
         g2 = gbtfitsload.GBTFITSLoad(testfile)
-        x = g2.summary()  # simple check that basic function works.
+        x = g2.summary()  # simple check that basic function works.  # noqa: F841

--- a/src/dysh/spectra/tests/test_scan.py
+++ b/src/dysh/spectra/tests/test_scan.py
@@ -4,7 +4,7 @@ from astropy import units as u
 from astropy.io import fits
 
 import dysh.util as util
-from dysh.fits import gbtfitsload, sdfitsload
+from dysh.fits import gbtfitsload
 
 
 class TestPSScan:

--- a/src/dysh/spectra/tests/test_spectra_core.py
+++ b/src/dysh/spectra/tests/test_spectra_core.py
@@ -53,7 +53,7 @@ class TestMeanTsys:
         mask_off = table[mask]["CAL"] == "F"
         table_on = table[mask][mask_on]
         table_off = table[mask][mask_off]
-        nchan = table["DATA"].shape[1]
+        nchan = table["DATA"].shape[1]  # noqa: F841
         tsys_dysh = core.mean_tsys(table_on["DATA"][0], table_off["DATA"][0], table_on["TCAL"][0])
 
         hdu = fits.open(gbtidl_file)
@@ -81,8 +81,8 @@ class TestMeanTsys:
         # Keys are the expected values, the rest the inputs.
         pairs = {
             1: {"exposure": 1, "delta_freq": 1, "tsys": 1},
-            1: {"exposure": 1 * u.s, "delta_freq": 1 * u.Hz, "tsys": 1 * u.K},
-            1: {"exposure": 1, "delta_freq": -1, "tsys": 1},
+            1: {"exposure": 1 * u.s, "delta_freq": 1 * u.Hz, "tsys": 1 * u.K},  # noqa: F601
+            1: {"exposure": 1, "delta_freq": -1, "tsys": 1},  # noqa: F601
             2: {"exposure": 1, "delta_freq": -1, "tsys": 0.5**0.5},
         }
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -38,7 +38,7 @@ def compare_spectrum(one, other, ignore_history=False, ignore_comments=False):
         if ignore_history and k == "_comments":
             continue
         elif k in ["_wcs"]:
-            v.to_header() == vars(other)[k].to_header()
+            v.to_header() == vars(other)[k].to_header()  # noqa: B015
         elif k in ["_spectral_axis"]:
             for k_, v_ in vars(v).items():
                 assert v_ == vars(vars(other)[k])[k_]
@@ -686,7 +686,7 @@ class TestSpectrum:
         sdf_file = data_dir / "AGBT17A_404_01_scan_19_prebaseline.fits"
         sdf = GBTFITSLoad(sdf_file)
         gbtidl_two_reg = loadfits(data_dir / "AGBT17A_404_01_scan_19_bmodel.fits")
-        gbtidl_no_reg = loadfits(data_dir / "AGBT17A_404_01_scan_19_noregion_bmodel.fits")
+        gbtidl_no_reg = loadfits(data_dir / "AGBT17A_404_01_scan_19_noregion_bmodel.fits")  # noqa: F841
 
         order = 3
         in_reg = [(99, 381), (449, 721)]

--- a/src/dysh/spectra/tests/test_vane.py
+++ b/src/dysh/spectra/tests/test_vane.py
@@ -1,10 +1,6 @@
 import numpy as np
-import pytest
-from astropy import units as u
-from astropy.io import fits
 
-import dysh.util as util
-from dysh.fits import gbtfitsload, sdfitsload
+from dysh.fits import gbtfitsload
 
 # from dysh.fits.core import calseq, getbeam, getnod, mean_data, plot_vegas, vanecal
 from dysh.util.files import dysh_data

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -4,7 +4,6 @@ Core utility definitions, classes, and functions
 
 import hashlib
 import numbers
-import re
 import sys
 from collections.abc import Sequence
 from pathlib import Path

--- a/src/dysh/util/download.py
+++ b/src/dysh/util/download.py
@@ -37,7 +37,6 @@ def from_url(url, path=Path(".")):
         client = httpx.Client(follow_redirects=True)
 
         with client.stream("GET", url) as resp:
-
             # Get the filename from the URL
             filename = Path(resp.url.path).name
 

--- a/src/dysh/util/files.py
+++ b/src/dysh/util/files.py
@@ -12,7 +12,6 @@
 
 import glob
 import os
-import sys
 from pathlib import Path
 
 import dysh.util as util

--- a/src/dysh/util/files.py
+++ b/src/dysh/util/files.py
@@ -164,7 +164,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
     #     - throw!?
     #     ? e.g. dysh_data('foo.fits') ->   sdfits='foo.fits'
 
-    if dysh_data == None and "DYSH_DATA" in os.environ:
+    if dysh_data == None and "DYSH_DATA" in os.environ:  # noqa: E711
         dysh_data = Path(os.environ["DYSH_DATA"])
     if verbose:
         print("DYSH_DATA:", dysh_data)
@@ -173,9 +173,9 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
 
     # sdfits:   the main place where GBO data reside
 
-    if sdfits != None:
+    if sdfits != None:  # noqa: E711
         if sdfits == "?":
-            if dysh_data == None:
+            if dysh_data == None:  # noqa: E711
                 dd = Path("/home/sdfits")
             else:
                 dd = dysh_data / "sdfits"
@@ -186,7 +186,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
             print("# -----------------")
             os.system(cmd)
             return None
-        if dysh_data != None:
+        if dysh_data != None:  # noqa: E711
             fn = dysh_data / Path("sdfits") / sdfits  # normally user is using a private sdfits
             if fn.exists():
                 return sdfits_offline(fn)
@@ -198,7 +198,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
 
     # test:   this should also be allowed to use util.get_project_testdata() as well
 
-    if test != None:
+    if test != None:  # noqa: E711
         if test == "?":
             print("# dysh_data::test")
             print("# ---------------")
@@ -206,12 +206,12 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
                 print(k, valid_dysh_test[k])
             return None
         my_test = minimum_string_match(test, list(valid_dysh_test.keys()))
-        if my_test != None:
+        if my_test != None:  # noqa: E711
             my_test = valid_dysh_test[my_test]
         else:
             my_test = test
         #
-        if dysh_data != None:
+        if dysh_data != None:  # noqa: E711
             fn = dysh_data / "testdata" / my_test
             if not fn.exists():
                 fn = util.get_project_testdata() / my_test
@@ -226,7 +226,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
 
     # example:  these can also obtain data via from_url (or perhaps astropy caching???)
 
-    if example != None:
+    if example != None:  # noqa: E711
         if example == "?":
             print("# dysh_data::example")
             print("# ------------------")
@@ -234,16 +234,16 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
                 print(k, valid_dysh_example[k])
             return None
         my_example = minimum_string_match(example, list(valid_dysh_example.keys()))
-        if my_example != None:
+        if my_example != None:  # noqa: E711
             my_example = valid_dysh_example[my_example]
         else:
             my_example = example
-        if dysh_data != None:
+        if dysh_data != None:  # noqa: E711
             fn = dysh_data / "example_data" / my_example
             if fn.exists():
                 return fn
             print("Odd-1, did not find", fn)
-        if dysh_data == None and os.path.exists(_example_data):
+        if dysh_data == None and os.path.exists(_example_data):  # noqa: E711
             fn = Path(_example_data) / my_example
             if fn.exists():
                 return fn
@@ -258,7 +258,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
             try:
                 filename = from_url(url)
                 print(f"\nRetrieved {filename}")
-            except:
+            except:  # noqa: E722
                 print(f"\nFailing to retrieve example {filename} ")
                 return None
         else:
@@ -267,7 +267,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
 
     # accept:   acceptance_testing/data - from_url not recommended (does not work on multifile fits)
 
-    if accept != None:
+    if accept != None:  # noqa: E711
         if accept == "?":
             print("# dysh_data::accept")
             print("# -----------------")
@@ -275,16 +275,16 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
                 print(k, valid_dysh_accept[k])
             return None
         my_accept = minimum_string_match(accept, list(valid_dysh_accept.keys()))
-        if my_accept != None:
+        if my_accept != None:  # noqa: E711
             my_accept = valid_dysh_accept[my_accept]
         else:
             my_accept = accept
-        if dysh_data != None:
+        if dysh_data != None:  # noqa: E711
             fn = dysh_data / "acceptance_testing/data" / my_accept
             if fn.exists():
                 return fn
             print("Odd-1, did not find", fn)
-        if dysh_data == None and os.path.exists(_accept_data):
+        if dysh_data == None and os.path.exists(_accept_data):  # noqa: E711
             fn = Path(_accept_data) / my_accept
             if fn.exists():
                 return fn
@@ -299,7 +299,7 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
             try:
                 filename = from_url(url)
                 print(f"\nRetrieved {filename}")
-            except:
+            except:  # noqa: E722
                 print(f"\nFailing to retrieve accept {filename}")
                 return None
         else:

--- a/src/dysh/util/gaincorrection.py
+++ b/src/dysh/util/gaincorrection.py
@@ -100,7 +100,7 @@ class BaseGainCorrection(ABC):
         """
         pass
 
-    def zenith_opacity(self, specval: Quantity, **kwargs) -> Union[float, np.ndarray]:
+    def zenith_opacity(self, specval: Quantity, **kwargs) -> Union[float, np.ndarray]:  # noqa: B027
         """
         Compute the zenith opacity.
 
@@ -134,7 +134,7 @@ class GBTGainCorrection(BaseGainCorrection):
 
     _valid_scales = ["ta", "ta*", "jy"]
 
-    def __init__(self, gain_correction_table: Path = None):
+    def __init__(self, gain_correction_table: Path = None):  # noqa: RUF013
         if gain_correction_table is None:
             gain_correction_table = get_project_configuration() / "gaincorrection.tab"
         self._gct = QTable.read(gain_correction_table, format="ascii.ecsv")
@@ -504,7 +504,7 @@ class GBTGainCorrection(BaseGainCorrection):
                 self._forecast = GBTWeatherForecast()
             except Exception as e:
                 self._forecast = None
-                raise Exception(
+                raise Exception(  # noqa: B904
                     f"Could not create GBTWeatherForecast object because {e!s} . Are you on the GBO network?"
                 )
         if mjd is None:

--- a/src/dysh/util/gaincorrection.py
+++ b/src/dysh/util/gaincorrection.py
@@ -505,7 +505,7 @@ class GBTGainCorrection(BaseGainCorrection):
             except Exception as e:
                 self._forecast = None
                 raise Exception(
-                    f"Could not create GBTWeatherForecast object because {str(e)} . Are you on the GBO network?"
+                    f"Could not create GBTWeatherForecast object because {e!s} . Are you on the GBO network?"
                 )
         if mjd is None:
             mjd = Time.now()

--- a/src/dysh/util/selection.py
+++ b/src/dysh/util/selection.py
@@ -436,7 +436,7 @@ class SelectionBase(DataFrame):
             tag = self._table.loc[_id]["TAG"]
             if s.equals(df):
                 tag = self._table.loc[_id]["TAG"]
-                warnings.warn(
+                warnings.warn(  # noqa: B028
                     f"A rule that results in an identical selection has already been added: ID: {_id}, TAG:{tag}."
                     " Ignoring."
                 )
@@ -567,11 +567,11 @@ class SelectionBase(DataFrame):
         elif multi_value_queries is not None and single_value_queries is None:
             query = multi_value_queries
         else:
-            warnings.warn("There was no data selection")  # should never happen
+            warnings.warn("There was no data selection")  # should never happen  # noqa: B028
             return False
         df = df.query(query)
         if df.empty:
-            warnings.warn("Your selection rule resulted in no data being selected. Ignoring.")
+            warnings.warn("Your selection rule resulted in no data being selected. Ignoring.")  # noqa: B028
             return False
         df.loc[:, "CHAN"] = proposed_channel_rule  # this column is normally None so no need to check if None first.
         self._addrow(row, df, tag)
@@ -638,7 +638,7 @@ class SelectionBase(DataFrame):
             else:
                 raise Exception(f"Couldn't parse value tuple {v} for key {k} as a range.")
         if df.empty:
-            warnings.warn("Your selection rule resulted in no data being selected. Ignoring.")
+            warnings.warn("Your selection rule resulted in no data being selected. Ignoring.")  # noqa: B028
             return
         self._addrow(row, df, tag)
 

--- a/src/dysh/util/selection.py
+++ b/src/dysh/util/selection.py
@@ -1307,7 +1307,7 @@ class Flag(SelectionBase):
                         echan = [echan]
                     echan = [int(float(x)) for x in echan]
                     # pair up echan and bchan
-                    vdict["channel"] = list(zip(bchan, echan))
+                    vdict["channel"] = list(zip(bchan, echan, strict=False))
                 elif bchan is not None and echan is None:
                     if not isinstance(bchan, list):
                         bchan = [bchan]
@@ -1315,13 +1315,13 @@ class Flag(SelectionBase):
                     echan = [2**25] * len(
                         bchan
                     )  # Set to a large number so it effectively spans the whole range from `bchan`.
-                    vdict["channel"] = tuple(zip(bchan, echan))
+                    vdict["channel"] = tuple(zip(bchan, echan, strict=False))
                 elif bchan is None and echan is not None:
                     if not isinstance(echan, list):
                         echan = [echan]
                     echan = [int(float(x)) for x in echan]
                     bchan = [0] * len(echan)
-                    vdict["channel"] = tuple(zip(bchan, echan))
+                    vdict["channel"] = tuple(zip(bchan, echan, strict=False))
 
                 if kwargs is not None:
                     vdict.update(kwargs)

--- a/src/dysh/util/tests/test_download.py
+++ b/src/dysh/util/tests/test_download.py
@@ -5,7 +5,6 @@ from dysh.util.download import from_url
 
 
 class TestDownload:
-
     def setup_method(self):
         self.url = "https://github.com/GreenBankObservatory/dysh/raw/main/testdata/AGBT05B_047_01/gbtidl/AGBT05B_047_01.getps.acs.fits"
 

--- a/src/dysh/util/tests/test_files.py
+++ b/src/dysh/util/tests/test_files.py
@@ -8,10 +8,10 @@ class TestUtil:
 
     def test_dysh_data(self):
         """Test dysh_data   (only limited testing possible)"""
-        assert duf.dysh_data() == None
+        assert duf.dysh_data() == None  # noqa: E711
         # test=
         f1 = duf.dysh_data(test="getps")
-        assert f1.exists() == True
+        assert f1.exists() == True  # noqa: E712
         # example=
         #   given the dynamic nature, not sure if we should test example="getps"
         #   since it needs either $DYSH_DATA or /home/dysh/example_data
@@ -20,7 +20,7 @@ class TestUtil:
         # sdfits=
         #   skipping
         # dysh_data=
-        assert duf.dysh_data("foo.fits", dysh_data="/tmp") == None
+        assert duf.dysh_data("foo.fits", dysh_data="/tmp") == None  # noqa: E711
         #   this assume DYSH_DATA is not present
         f2 = duf.dysh_data(example="test1")
         assert f2.name == Path("AGBT05B_047_01.raw.acs.fits").name

--- a/src/dysh/util/tests/test_gaincorrection.py
+++ b/src/dysh/util/tests/test_gaincorrection.py
@@ -122,7 +122,9 @@ class TestGainCorrection:
         for d in self.dates[[5, 7]]:
             # first find the elevation angle where the gain curve reaches a maximum
             maxpoint = minimize_scalar(
-                lambda x: -f(angle=x * u.degree, date=d, zd=False), bounds=[0, 90], method="bounded"
+                lambda x: -f(angle=x * u.degree, date=d, zd=False),  # noqa: B023
+                bounds=[0, 90],
+                method="bounded",  # noqa: B023, RUF100
             )
             # Evaluate the aperture efficiency at the given requencies and the elevation of the gain maximum
             a = maxpoint.x * u.degree

--- a/src/dysh/util/tests/test_selection.py
+++ b/src/dysh/util/tests/test_selection.py
@@ -8,7 +8,6 @@ import dysh
 from dysh import util
 from dysh.fits import gbtfitsload
 from dysh.util.files import dysh_data
-from dysh.util.selection import Flag
 
 dysh_root = pathlib.Path(dysh.__file__).parent.resolve()
 

--- a/src/dysh/util/tests/test_util_core.py
+++ b/src/dysh/util/tests/test_util_core.py
@@ -23,10 +23,10 @@ class TestUtil:
         """Test minimum_string_match function"""
         s = ["alpha", "beta", "gamma", "gemma"]
         assert du.minimum_string_match("a", s) == "alpha"
-        assert du.minimum_string_match("A", s) == None
-        assert du.minimum_string_match("g", s) == None
+        assert du.minimum_string_match("A", s) == None  # noqa: E711
+        assert du.minimum_string_match("g", s) == None  # noqa: E711
         assert du.minimum_string_match("ga", s) == "gamma"
-        assert du.minimum_string_match("am", s) == None
+        assert du.minimum_string_match("am", s) == None  # noqa: E711
 
     def test_powerof2(self):
         """Test powerof2 function"""

--- a/src/dysh/util/tests/test_weatherforecast.py
+++ b/src/dysh/util/tests/test_weatherforecast.py
@@ -5,6 +5,7 @@ Created on Mon Feb 17 15:39:26 2025
 
 @author: mpound
 """
+
 import astropy.units as u
 import numpy as np
 import pytest

--- a/src/dysh/util/tests/test_weatherforecast_gbo_only.py
+++ b/src/dysh/util/tests/test_weatherforecast_gbo_only.py
@@ -4,7 +4,6 @@
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.time import Time
 
 from dysh.spectra import Spectrum
 from dysh.util.gaincorrection import GBTGainCorrection

--- a/src/dysh/util/weatherforecast.py
+++ b/src/dysh/util/weatherforecast.py
@@ -5,6 +5,7 @@ Created on Wed Feb 12 13:13:33 2025
 
 @author: mpound
 """
+
 import ast
 import re
 import subprocess

--- a/src/dysh/util/weatherforecast.py
+++ b/src/dysh/util/weatherforecast.py
@@ -16,7 +16,6 @@ from typing import Union
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import SpectralCoord
 from astropy.time import Time
 from astropy.units.quantity import Quantity
 from numpy.polynomial.polynomial import Polynomial
@@ -25,7 +24,7 @@ from pandas import DataFrame
 from ..log import logger
 from .core import to_mjd_list, to_quantity_list
 
-__all__ = ["BaseWeatherForecast", "GBTWeatherForecast", "GBTForecastScriptInterface"]
+__all__ = ["BaseWeatherForecast", "GBTForecastScriptInterface", "GBTWeatherForecast"]
 
 
 class BaseWeatherForecast(ABC):

--- a/src/dysh/util/weatherforecast.py
+++ b/src/dysh/util/weatherforecast.py
@@ -32,7 +32,11 @@ class BaseWeatherForecast(ABC):
 
     @abstractmethod
     def fetch(
-        specval: Quantity, valueType: list = None, mjd: Union[Time, np.ndarray] = None, coeffs=None, **kwargs
+        specval: Quantity,
+        valueType: list = None,  # noqa: RUF013
+        mjd: Union[Time, np.ndarray] = None,
+        coeffs=None,
+        **kwargs,  # noqa: RUF013, RUF100
     ) -> np.ndarray:
         pass
 
@@ -366,7 +370,7 @@ class GBTForecastScriptInterface:
         # frequency ranges as of 2/2025.
         self.fr = [2.0, 22.0, 22.0 + 1e-9, 50.0, 67.0, 116.0]  # GHz
         ccols = [f"c{n}" for n in np.arange(self._MAX_COEFFICIENTS)]
-        self._fitcols = ["MJD", "freqLoGHz", "freqHiGHz"] + ccols
+        self._fitcols = ["MJD", "freqLoGHz", "freqHiGHz"] + ccols  # noqa: RUF005
         self._valid_vartypes = [
             "Opacity",
             "Tatm",
@@ -406,7 +410,11 @@ class GBTForecastScriptInterface:
     # and the high order coefficients for the other ranges will be set to zero.
     # Note: input MJDs are rounded to the nearest ~5 minutes.  Data are only taken every hour
     def __call__(
-        self, vartype: str = "Opacity", freq: list = None, mjd: list = None, coeffs: bool = True
+        self,
+        vartype: str = "Opacity",
+        freq: list = None,  # noqa: RUF013
+        mjd: list = None,  # noqa: RUF013
+        coeffs: bool = True,  # noqa: RUF013, RUF100
     ) -> np.ndarray:
         r"""Call the GBO weather script and parse the results into numbers.
 

--- a/testdata/extract_rows.py
+++ b/testdata/extract_rows.py
@@ -4,10 +4,11 @@
 # out to a new SDFITS file.
 
 import sys
+
 import numpy as np
 from astropy.io import fits
-from dysh.fits.gbtfitsload import GBTFITSLoad
 
+from dysh.fits.gbtfitsload import GBTFITSLoad
 
 if len(sys.argv) < 3:
     print("Usage: %s row_min row_max | row1 row2 row3 .... rowN" % sys.argv[0])

--- a/uv.lock
+++ b/uv.lock
@@ -779,11 +779,13 @@ dependencies = [
 all = [
     { name = "ipympl" },
     { name = "jupyter" },
+    { name = "jupyter-nbextensions-configurator" },
     { name = "jupyterlab" },
 ]
 nb = [
     { name = "ipympl" },
     { name = "jupyter" },
+    { name = "jupyter-nbextensions-configurator" },
     { name = "jupyterlab" },
 ]
 
@@ -801,6 +803,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "ruff" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-autobuild" },
@@ -821,6 +824,8 @@ requires-dist = [
     { name = "jplephem" },
     { name = "jupyter", marker = "extra == 'all'" },
     { name = "jupyter", marker = "extra == 'nb'" },
+    { name = "jupyter-nbextensions-configurator", marker = "extra == 'all'", specifier = ">=0.6.4" },
+    { name = "jupyter-nbextensions-configurator", marker = "extra == 'nb'", specifier = ">=0.6.4" },
     { name = "jupyterlab", marker = "extra == 'all'" },
     { name = "jupyterlab", marker = "extra == 'nb'" },
     { name = "matplotlib" },
@@ -847,6 +852,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-book-theme" },
@@ -1382,6 +1388,19 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-contrib-core"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "notebook" },
+    { name = "setuptools" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/94/0d37e5b49ea1c8bf204c46f9b0257c1f3319a4ab88acbd401da2cab25e55/jupyter_contrib_core-0.4.2.tar.gz", hash = "sha256:1887212f3ca9d4487d624c0705c20dfdf03d5a0b9ea2557d3aaeeb4c38bdcabb", size = 17490 }
+
+[[package]]
 name = "jupyter-core"
 version = "5.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1423,6 +1442,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/b4/3200b0b09c12bc3b72d943d923323c398eff382d1dcc7c0dbc8b74630e40/jupyter-lsp-2.2.5.tar.gz", hash = "sha256:793147a05ad446f809fd53ef1cd19a9f5256fd0a2d6b7ce943a982cb4f545001", size = 48741 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/e0/7bd7cff65594fd9936e2f9385701e44574fc7d721331ff676ce440b14100/jupyter_lsp-2.2.5-py3-none-any.whl", hash = "sha256:45fbddbd505f3fbfb0b6cb2f1bc5e15e83ab7c79cd6e89416b248cb3c00c11da", size = 69146 },
+]
+
+[[package]]
+name = "jupyter-nbextensions-configurator"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-contrib-core" },
+    { name = "jupyter-core" },
+    { name = "jupyter-server" },
+    { name = "notebook" },
+    { name = "pyyaml" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/fe/cffb14a4fbb43cf276aa3047e42c3f9ecfda851ba3c466295401f6b1e085/jupyter_nbextensions_configurator-0.6.4-py2.py3-none-any.whl", hash = "sha256:fe7a7b0805b5926449692fb077e0e659bab8b27563bc68cba26854532fdf99c7", size = 466890 },
 ]
 
 [[package]]
@@ -2666,6 +2702,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/23/cd8f566de444a137bc1ee5795e47069a947e60810ba4152886fe5308e1b7/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:e35ba67d65d49080e8e5a1dd40101fccdd9798adb9b050ff670b7d74fa41c566", size = 583780 },
     { url = "https://files.pythonhosted.org/packages/8d/63/79c3602afd14d501f751e615a74a59040328da5ef29ed5754ae80d236b84/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:26fd7cac7dd51011a245f29a2cc6489c4608b5a8ce8d75661bb4a1066c52dfbe", size = 553619 },
     { url = "https://files.pythonhosted.org/packages/9f/2e/c5c1689e80298d4e94c75b70faada4c25445739d91b94c211244a3ed7ed1/rpds_py-0.22.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:177c7c0fce2855833819c98e43c262007f42ce86651ffbb84f37883308cb0e7d", size = 233338 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/61/fb87430f040e4e577e784e325351186976516faef17d6fcd921fe28edfd7/ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94", size = 3857511 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/99/102578506f0f5fa29fd7e0df0a273864f79af044757aef73d1cae0afe6ad/ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477", size = 10113146 },
+    { url = "https://files.pythonhosted.org/packages/74/ad/5cd4ba58ab602a579997a8494b96f10f316e874d7c435bcc1a92e6da1b12/ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272", size = 10867092 },
+    { url = "https://files.pythonhosted.org/packages/fc/3e/d3f13619e1d152c7b600a38c1a035e833e794c6625c9a6cea6f63dbf3af4/ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9", size = 10224082 },
+    { url = "https://files.pythonhosted.org/packages/90/06/f77b3d790d24a93f38e3806216f263974909888fd1e826717c3ec956bbcd/ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb", size = 10394818 },
+    { url = "https://files.pythonhosted.org/packages/99/7f/78aa431d3ddebfc2418cd95b786642557ba8b3cb578c075239da9ce97ff9/ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3", size = 9952251 },
+    { url = "https://files.pythonhosted.org/packages/30/3e/f11186d1ddfaca438c3bbff73c6a2fdb5b60e6450cc466129c694b0ab7a2/ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74", size = 11563566 },
+    { url = "https://files.pythonhosted.org/packages/22/6c/6ca91befbc0a6539ee133d9a9ce60b1a354db12c3c5d11cfdbf77140f851/ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608", size = 12208721 },
+    { url = "https://files.pythonhosted.org/packages/19/b0/24516a3b850d55b17c03fc399b681c6a549d06ce665915721dc5d6458a5c/ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f", size = 11662274 },
+    { url = "https://files.pythonhosted.org/packages/d7/65/76be06d28ecb7c6070280cef2bcb20c98fbf99ff60b1c57d2fb9b8771348/ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147", size = 13792284 },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/4ceed7147e05852876f3b5f3fdc23f878ce2b7e0b90dd6e698bda3d20787/ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b", size = 11327861 },
+    { url = "https://files.pythonhosted.org/packages/c4/78/4935ecba13706fd60ebe0e3dc50371f2bdc3d9bc80e68adc32ff93914534/ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9", size = 10276560 },
+    { url = "https://files.pythonhosted.org/packages/81/7f/1b2435c3f5245d410bb5dc80f13ec796454c21fbda12b77d7588d5cf4e29/ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab", size = 9945091 },
+    { url = "https://files.pythonhosted.org/packages/39/c4/692284c07e6bf2b31d82bb8c32f8840f9d0627d92983edaac991a2b66c0a/ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630", size = 10977133 },
+    { url = "https://files.pythonhosted.org/packages/94/cf/8ab81cb7dd7a3b0a3960c2769825038f3adcd75faf46dd6376086df8b128/ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f", size = 11378514 },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/a647fa4f316482dacf2fd68e8a386327a33d6eabd8eb2f9a0c3d291ec549/ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc", size = 10319835 },
+    { url = "https://files.pythonhosted.org/packages/86/54/3c12d3af58012a5e2cd7ebdbe9983f4834af3f8cbea0e8a8c74fa1e23b2b/ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080", size = 11373713 },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/dd813703af8a1e2ac33bf3feb27e8a5ad514c9f219df80c64d69807e7f71/ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4", size = 10441990 },
 ]
 
 [[package]]


### PR DESCRIPTION
Ruff is a linting and formatting tool for Python. It replaces black, isort, pylint, and [many other such tools](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)

Ruff's autoformatting is generally identical to black's, but there are _some_ differences: https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black

> Specifically, the formatter is intended to emit near-identical output when run over Black-formatted code. When run over extensive Black-formatted projects like Django and Zulip, > 99.9% of lines are formatted identically. When migrating an existing project from Black to Ruff, you should expect to see a few differences on the margins, but the vast majority of your code should be unchanged.

This PR migrates us to ruff and removes use of black, isort and pylint. This includes updating `.pre-commit-config.toml` to use ruff.

This PR also runs `ruff check --fix`, which auto-fixes all of the "fixable" issues that it finds. There are still a lot of linter issues (this is not specific to ruff; they were there with pylint also)