### PR TITLE
Install all optional deps into dev envs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
   "sphinx-design",
   "sphinx-inline-tabs",
   "sphinxcontrib-mermaid",
+  "dysh[all]", # ensure that all extras are included in dev envs
 ]
 
 [project.urls]


### PR DESCRIPTION
Currently you must remember to do `uv sync --all-extras` in order to pull in the notebook dependencies (`dysh[all]`).

This PR changes the behavior such that a bare `uv sync` will install all optional dependencies

Behavior of pip installation is unchanged (i.e. this does not affect user installations of dysh)
