### PR TITLE
Fix unit test that fails at GBO

### DIFF
--- a/src/dysh/util/tests/test_files.py
+++ b/src/dysh/util/tests/test_files.py
@@ -23,4 +23,4 @@ class TestUtil:
         assert duf.dysh_data("foo.fits", dysh_data="/tmp") == None
         #   this assume DYSH_DATA is not present
         f2 = duf.dysh_data(example="test1")
-        assert f2 == Path("AGBT05B_047_01.raw.acs.fits")
+        assert f2.name == Path("AGBT05B_047_01.raw.acs.fits").name


### PR DESCRIPTION
Two paths are being compared, but the result is that an absolute path is compared to a relative path, which fails (at least at GBO)

The fix here is to compare the names to each other rather than the full path
