### PR TITLE
354 sdfitsload does not print the filepath

### DIFF
--- a/notebooks/developer/test_online.py
+++ b/notebooks/developer/test_online.py
@@ -26,7 +26,9 @@ from dysh.util import get_project_testdata
 #%%  debugging
 
 import dysh
-dysh.log.init_logging(3)   # 0=ERROR 1=WARNING 2=INFO 3=DEBUG
+#dysh.log.init_logging(3)   # 0=ERROR 1=WARNING 2=INFO 3=DEBUG
+dysh.log.init_logging(0)
+
 
 #%%  classic getps
 

--- a/notebooks/developer/test_online.py
+++ b/notebooks/developer/test_online.py
@@ -117,13 +117,11 @@ print(sdf2)
 from dysh.fits.gbtfitsload import GBTFITSLoad
     
 f1='AGBT15B_287_33'
-sdf1 = GBTOffline(f1)    # ok
+sdf1 = GBTOffline(f1)  
 print(sdf1.filename) 
-# /home/teuben/GBT/dysh_data/sdfits/AGBT15B_287_33/AGBT15B_287_33.raw.vegas
 
 sdf2 = GBTFITSLoad(sdf1.filename)
 print(sdf2.filename) 
-# AttributeError: 'GBTFITSLoad' object has no attribute '_filename'
 print(sdf2.filenames())
 
 sdf3 = GBTFITSLoad(dysh_data(f1))
@@ -131,7 +129,7 @@ print(sdf3.filename)
 
 
 
-#%% issue 550 with only one file kin the top level
+#%% issue 550 with only one file in the top level
 
 f1 = 'test123'
 sdf1 = GBTOffline(f1)    # ok
@@ -152,10 +150,10 @@ print(sdf4.filename)
 
 file1 = dysh_data(test='TGBT21A_501_11/TGBT21A_501_11.raw.vegas.fits')
 sdf1 = SDFITSLoad(file1)
-print(sdf1)     # fails
+print(sdf1)   
 
 sdf2= GBTFITSLoad(file1)
-print(sdf2)      # works
+print(sdf2)    
 
 #%%  20m data
 from dysh.fits import gb20mfitsload

--- a/notebooks/developer/test_online.py
+++ b/notebooks/developer/test_online.py
@@ -162,5 +162,3 @@ f1 = dysh_data(test="20m/Skynet_60476_DR21_118886_68343.cyb.fits")
 sdf1 = gb20mfitsload.GB20MFITSLoad(f1)
 
 sdf1.filename
-
-

--- a/notebooks/developer/test_online.py
+++ b/notebooks/developer/test_online.py
@@ -103,11 +103,9 @@ sdf = GBTOnline('online.fits')
 
 sdf1 = GBTOffline("TRFI_122024_U1")
 print(sdf1.filename) # successfully returns file path
-/home/sdfits/TRFI_122024_U1/TRFI_122024_U1.raw.vegas
 
 sdf2 = GBTFITSLoad("/home/sdfits/TRFI_122024_U1/TRFI_122024_U1.raw.vegas")
 print(sdf2.filename) # fails to return file path
-AttributeError: 'GBTSDFITSLoad' object has no attribute '_filename'
 
 # however printing the object works in both cases
 print(sdf1)

--- a/notebooks/developer/test_online.py
+++ b/notebooks/developer/test_online.py
@@ -97,3 +97,62 @@ sdf
 
 
 sdf = GBTOnline('online.fits')
+
+
+#%%  issue 550
+
+sdf1 = GBTOffline("TRFI_122024_U1")
+print(sdf1.filename) # successfully returns file path
+/home/sdfits/TRFI_122024_U1/TRFI_122024_U1.raw.vegas
+
+sdf2 = GBTFITSLoad("/home/sdfits/TRFI_122024_U1/TRFI_122024_U1.raw.vegas")
+print(sdf2.filename) # fails to return file path
+AttributeError: 'GBTSDFITSLoad' object has no attribute '_filename'
+
+# however printing the object works in both cases
+print(sdf1)
+print(sdf2)
+
+#%% issue 550 my laptop
+from dysh.fits.gbtfitsload import GBTFITSLoad
+    
+f1='AGBT15B_287_33'
+sdf1 = GBTOffline(f1)    # ok
+print(sdf1.filename) 
+# /home/teuben/GBT/dysh_data/sdfits/AGBT15B_287_33/AGBT15B_287_33.raw.vegas
+
+sdf2 = GBTFITSLoad(sdf1.filename)
+print(sdf2.filename) 
+# AttributeError: 'GBTFITSLoad' object has no attribute '_filename'
+print(sdf2.filenames())
+
+sdf3 = GBTFITSLoad(dysh_data(f1))
+print(sdf3.filename)
+
+
+
+#%% issue 550 with only one file kin the top level
+
+f1 = 'test123'
+sdf1 = GBTOffline(f1)    # ok
+print(sdf1.filename) 
+
+sdf2 = GBTFITSLoad(sdf1.filename)
+print(sdf2.filename) 
+
+sdf3 = GBTFITSLoad('/home/teuben/GBT/dysh_data/sdfits/test123/online168.fits')
+print(sdf3.filename) 
+
+sdf4 = SDFITSLoad('/home/teuben/GBT/dysh_data/sdfits/test123/online168.fits')
+print(sdf4.filename)
+
+
+#%%  354
+
+
+file1 = dysh_data(test='TGBT21A_501_11/TGBT21A_501_11.raw.vegas.fits')
+sdf1 = SDFITSLoad(file1)
+print(sdf1)     # fails
+
+sdf2= GBTFITSLoad(file1)
+print(sdf2)      # work

--- a/notebooks/developer/test_online.py
+++ b/notebooks/developer/test_online.py
@@ -155,4 +155,14 @@ sdf1 = SDFITSLoad(file1)
 print(sdf1)     # fails
 
 sdf2= GBTFITSLoad(file1)
-print(sdf2)      # work
+print(sdf2)      # works
+
+#%%  20m data
+from dysh.fits import gb20mfitsload
+
+f1 = dysh_data(test="20m/Skynet_60476_DR21_118886_68343.cyb.fits")
+sdf1 = gb20mfitsload.GB20MFITSLoad(f1)
+
+sdf1.filename
+
+

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -83,6 +83,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         if path.is_file():
             logger.debug(f"Treating given path {path} as a file")
             self._sdf.append(SDFITSLoad(path, source, hdu, **kwargs_opts))
+            if not hasattr(self, "_filename"):
+                self._filename = self._sdf[0].filename
         elif path.is_dir():
             logger.debug(f"Treating given path {path} as a directory")
             # Find all the FITS files in the directory and sort alphabetically
@@ -94,6 +96,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 self._sdf.append(SDFITSLoad(f, source, hdu, **kwargs_opts))
             if len(self._sdf) == 0:  # fixes issue 381
                 raise Exception(f"No FITS files found in {fileobj}.")
+            if not hasattr(self, "_filename"):
+                self._filename = self._sdf[0].filename.parent
             self.add_history(f"This GBTFITSLoad encapsulates the files: {self.filenames()}", add_time=True)
         else:
             raise Exception(f"{fileobj} is not a file or directory path")

--- a/src/dysh/fits/tests/test_gb20mfitsload.py
+++ b/src/dysh/fits/tests/test_gb20mfitsload.py
@@ -17,8 +17,8 @@ class TestGB20mFITSload:
         """
         Test basic filename
         """
-        assert(self.data_path == self.sdfits.filename)
-        
+        assert self.data_path == self.sdfits.filename
+
     def test_find_cal(self):
         """
         Test that the indices for finding the calibration data

--- a/src/dysh/fits/tests/test_gb20mfitsload.py
+++ b/src/dysh/fits/tests/test_gb20mfitsload.py
@@ -13,6 +13,12 @@ class TestGB20mFITSload:
         with pytest.warns(UserWarning):
             self.sdfits = gb20mfitsload.GB20MFITSLoad(self.data_path)
 
+    def test_names(self):
+        """
+        Test basic filename
+        """
+        assert(self.data_path == self.sdfits.filename)
+        
     def test_find_cal(self):
         """
         Test that the indices for finding the calibration data

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -57,7 +57,21 @@ class TestGBTFITSLoad:
             filename = os.path.basename(fnm)
             sdf = gbtfitsload.GBTFITSLoad(fnm)
             assert len(sdf.index(bintable=0)) == expected[filename]
+            
+    def test_names(self):
+        """
+        Test basic filename
+        """
+        fnm = Path(self._file_list[0])  # why Path() here, and not in sdfits
+        sdf = gbtfitsload.GBTFITSLoad(fnm)
+        assert(fnm == sdf.filename)
 
+        fnm = Path(f"{self.data_dir}/AGBT20B_014_03.raw.vegas")
+        sdf = gbtfitsload.GBTFITSLoad(fnm)
+        assert(fnm == sdf.filename)
+        
+        
+        
     def test_getspec(self):
         """
         Test that a GBTFITSLoad object can use the `getspec` function.

--- a/src/dysh/fits/tests/test_sdfitsload.py
+++ b/src/dysh/fits/tests/test_sdfitsload.py
@@ -50,6 +50,15 @@ class TestSDFITSLoad:
             sdf = SDFITSLoad(fnm)
             assert len(sdf._index) == expected[filename]
 
+    def test_names(self):
+        """
+        Test basic filename
+        """
+        filename = "TGBT21A_501_11.raw.vegas.fits"
+        fnm = self._file_list[0]  # note fnm is a string
+        sdf = SDFITSLoad(fnm)
+        assert(fnm == sdf.filename)
+
     def test_getspec(self):
         """
         Test that a SDFITSLoad object can use the `getspec` function.

--- a/src/dysh/util/files.py
+++ b/src/dysh/util/files.py
@@ -112,6 +112,8 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
 
     1) if $DYSH_DATA exist (and this is a new proposal), it will prepend
        that to the argument of get_dysh_data() and check for existence
+       if $DYSH_DATA does not exist, but $SDFITS_DATA exists (a GBTIDL feature)
+       it will use that
     2) if /home/dysh exists, it will prepend this and check for existence
        this will keep GBO people happy.  Offsite a symlink should also work.
     3) if none of those gave a valid name, it will fall back to making a URL

--- a/src/dysh/util/tests/test_files.py
+++ b/src/dysh/util/tests/test_files.py
@@ -23,4 +23,4 @@ class TestUtil:
         assert duf.dysh_data("foo.fits", dysh_data="/tmp") == None
         #   this assume DYSH_DATA is not present
         f2 = duf.dysh_data(example="test1")
-        assert f2 == Path("AGBT05B_047_01.raw.acs.fits")
+        assert f2.name == Path("AGBT05B_047_01.raw.acs.fits").name


### PR DESCRIPTION
Ensured the .filename attribute is now populated when it was not.