### PR TITLE
Issue 553

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from astropy import units as u
 from astropy.io import fits
 
-from astropy import units as u
 from dysh.log import logger
 
 from ..coordinates import Observatory, decode_veldef, eq2hor, hor2eq

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -103,8 +103,9 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         if kwargs_opts["index"]:
             self._create_index_if_needed(skipflags)
             self._update_radesys()
-        if kwargs_opts["fix_ka"]:
-            self._fix_ka_rx_if_needed()
+            # This only works if the index was created.
+            if kwargs_opts["fix_ka"]:
+                self._fix_ka_rx_if_needed()
         # We cannot use this to get mmHg as it will disable all default astropy units!
         # https://docs.astropy.org/en/stable/api/astropy.units.cds.enable.html#astropy.units.cds.enable
         # cds.enable()  # to get mmHg

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from astropy import units as u
 from astropy.io import fits
 
+from astropy import units as u
 from dysh.log import logger
 
 from ..coordinates import Observatory, decode_veldef, eq2hor, hor2eq
@@ -2086,6 +2086,22 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         self._fix_column("RADESYS", radesys["Galactic"], {"CTYPE2": "GLON"})
 
     def _fix_column(self, column, new_val, mask_dict):
+        """
+        Update the values of an existing SDFITS `column` with `new_val` where `mask_dict` is true.
+        This updates `GBTFITSLoad._index` and `GBTFITSLoad._sdf.index`.
+        This is mainly used to "fix" values.
+
+        Parameters
+        ----------
+        column : str
+            SDFITS column to update.
+        new_val : str or float
+            New value for `column`.
+        mask_dict : dict
+            Dictionary with column names and column values as keys and values.
+            This will be used to determine where `GBTFITSLoad[key] == value`.
+            Multiple keys and values will be combined using `numpy.logical_and`.
+        """
         _mask = self._column_mask(mask_dict)
         if _mask.sum() == 0:
             return

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -68,10 +68,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
 
     @log_call_to_history
     def __init__(self, fileobj, source=None, hdu=None, skipflags=False, **kwargs):
-        kwargs_opts = {
-            "index": True,  # only set to False for performance testing.
-            "verbose": False,
-        }
+        kwargs_opts = {"index": True, "verbose": False, "fix_ka": True}  # only set to False for performance testing.
         HistoricalBase.__init__(self)
         kwargs_opts.update(kwargs)
         path = Path(fileobj)
@@ -106,6 +103,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         if kwargs_opts["index"]:
             self._create_index_if_needed(skipflags)
             self._update_radesys()
+        if kwargs_opts["fix_ka"]:
+            self._fix_ka_rx_if_needed()
         # We cannot use this to get mmHg as it will disable all default astropy units!
         # https://docs.astropy.org/en/stable/api/astropy.units.cds.enable.html#astropy.units.cds.enable
         # cds.enable()  # to get mmHg
@@ -1564,56 +1563,24 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         return scanblock
         # end of getfs()
 
-    def _fix_ka_rx_if_needed(self, df, fdnum, plnum):
-        """The Ka band receiver had mislabeled PLNUM for a period of time.
-        This code returns the correct PLNUM for the given feed number
+    def _fix_ka_rx_if_needed(self):
+        """The Ka band receiver had mislabeled FDNUM for a period of time.
+        This corrects FDNUM for the given polarization (the Ka beams measure orthogonal polarizations).
 
         **Note**:   I don't know what date range this was effective, so this
         method may do the wrong thing for some data!
 
         See issue #160 https://github.com/GreenBankObservatory/dysh/issues/160
-
-        Parameters
-        ----------
-        df : `~pandas.DataFrame`
-            The index of the down-selected data.
-        fdnum: int
-            The feed number selected.
-        plnum: int
-            The original polarization number
-
-        Returns
-        -------
-        corrected_plnum : int
-            The corrected polarization number
         """
         # Check if we are dealing with Ka data before the beam switch.
-        rx = np.unique(df["FRONTEND"])
+        rx = set(self["FRONTEND"])
         if "Rcvr26_40" not in rx:
             return
 
-        corrected_plnum = plnum
-        if len(rx) > 1:
-            # Does this ever actually happen?
-            raise TypeError(f"More than one receiver {rx} for the selected scan.")
-        elif rx[0] == "Rcvr26_40":  # and df["DATE-OBS"][-1] < xxxx
-            # Switch the polarizations to match the beams,
-            # for this receiver only because it has had its feeds
-            # mislabelled since $DATE.
-            # For the rest of the receivers the method should use
-            # the same polarization for the selected feeds.
-            # See also issue #160
-            if fdnum == 0:
-                corrected_plnum = 1
-                logger.info(
-                    f"Fixing PLNUM mislabel {plnum} for Rcvr26_40 feed {fdnum}, PLNUM changed to {corrected_plnum}"
-                )
-            elif fdnum == 1:
-                corrected_plnum = 0
-                logger.info(
-                    f"Fixing PLNUM mislabel {plnum} for Rcvr26_40 feed {fdnum}, PLNUM changed to {corrected_plnum}"
-                )
-        return corrected_plnum
+        self._fix_column("FDNUM", 1, {"FRONTEND": "Rcvr26_40", "PLNUM": 1})
+        logger.info(f"Fixing FDNUM mislabel for Rcvr26_40. FDNUM 0 changed to 1")
+        self._fix_column("FDNUM", 0, {"FRONTEND": "Rcvr26_40", "PLNUM": 0})
+        logger.info(f"Fixing FDNUM mislabel for Rcvr26_40. FDNUM 1 changed to 0")
 
     # @todo sig/cal no longer needed?
     @log_call_to_result

--- a/src/dysh/fits/sdfitsload.py
+++ b/src/dysh/fits/sdfitsload.py
@@ -633,13 +633,28 @@ class SDFITSLoad(object):
     # def __len__(self):  # this has no meaning for multiple bintables
     #    return self._nrows
 
-    def _ctype_mask(self, ctype_dict):
-        ctype_mask = np.zeros((len(ctype_dict), len(self[next(iter(ctype_dict.keys()))])), dtype=bool)
-        for i, (k, v) in enumerate(ctype_dict.items()):
-            ctype_mask[i, :] = self[k] == v
-        if ctype_mask.shape[0] > 1:
-            ctype_mask = np.logical_and(*ctype_mask)
-        return ctype_mask.ravel()
+    def _column_mask(self, column_dict):
+        """
+        Generate a boolean array given a dictionary.
+        The keys in the dictionary are the column names and the values the column values.
+        It will combine multiple dictionary items using `numpy.logical_and`.
+
+        Parameters
+        ----------
+        column_dict : dict
+            Dictionary with column names and column values as keys and values.
+
+        Returns
+        -------
+        _mask : `numpy.array`
+            Array of booleans with True where the column equals column value.
+        """
+        _mask = np.zeros((len(column_dict), len(self[next(iter(column_dict.keys()))])), dtype=bool)
+        for i, (k, v) in enumerate(column_dict.items()):
+            _mask[i, :] = self[k] == v
+        if _mask.shape[0] > 1:
+            _mask = np.logical_and(*_mask)
+        return _mask.ravel()
 
     def __repr__(self):
         return str(self._filename)

--- a/src/dysh/spectra/tests/test_scan.py
+++ b/src/dysh/spectra/tests/test_scan.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
-from astropy import units as u
 from astropy.io import fits
 
 import dysh.util as util
+from astropy import units as u
 from dysh.fits import gbtfitsload, sdfitsload
 
 
@@ -185,7 +185,7 @@ class TestSubBeamNod:
         # snodka-style. Need test for method='cycle'
         sdf = gbtfitsload.GBTFITSLoad(sdf_file)
         sbn = sdf.subbeamnod(
-            scan=43, sig=None, cal=None, ifnum=0, fdnum=1, plnum=0, calibrate=True, weights="tsys", method="scan"
+            scan=43, sig=None, cal=None, ifnum=0, fdnum=1, plnum=1, calibrate=True, weights="tsys", method="scan"
         )
 
         # Load the GBTIDL result.
@@ -253,8 +253,8 @@ class TestSubBeamNod:
             sdf["TCAL"] = tcal
 
         # Calibrate.
-        sbn_cycle = sdf.subbeamnod(scan=43, fdnum=0, plnum=1, ifnum=0).timeaverage()
-        sbn_scan = sdf.subbeamnod(scan=43, fdnum=0, plnum=1, ifnum=0, method="scan").timeaverage()
+        sbn_cycle = sdf.subbeamnod(scan=43, fdnum=1, plnum=1, ifnum=0).timeaverage()
+        sbn_scan = sdf.subbeamnod(scan=43, fdnum=1, plnum=1, ifnum=0, method="scan").timeaverage()
 
         # Check data over a frequency interval.
         s_sbn = slice(30.0 * u.GHz, 30.5 * u.GHz)
@@ -277,7 +277,7 @@ class TestSubBeamNod:
         assert pytest.approx(rms_cycle.value, abs=1e-2) == rms_scan.value
 
         # Number of rows.
-        assert sdf.subbeamnod(scan=43, fdnum=0, plnum=1, ifnum=0, method="scan")[0].nrows == 96
+        assert sdf.subbeamnod(scan=43, fdnum=1, plnum=1, ifnum=0, method="scan")[0].nrows == 96
 
         # Line amplitude.
         assert pytest.approx(sbn_cycle.data.max() - tcont, rms_cycle.value) == a

--- a/testdata/AGBT18A_333_21/README.md
+++ b/testdata/AGBT18A_333_21/README.md
@@ -1,0 +1,37 @@
+# AGBT18A_333_21
+
+
+## Making the test data
+
+Used GBTIDL to generate the input and output files.
+
+To generate the input file:
+
+```IDL
+filein,"/home/dysh/acceptance_testing/data/AGBT18A_333_21/AGBT18A_333_21.raw.vegas"
+fileout,"AGBT18A_333_21.raw.vegas/AGBT18A_333_21.raw.vegas.testrim.fits"
+gettp,11,ifnum=0,plnum=0,fdnum=1,cal=1                                         
+keep
+gettp,11,ifnum=0,plnum=1,fdnum=0,cal=1
+keep
+gettp,11,ifnum=0,plnum=0,fdnum=1,cal=0
+keep
+gettp,11,ifnum=0,plnum=1,fdnum=0,cal=0
+keep
+gettp,12,ifnum=0,plnum=0,fdnum=1,cal=1                                  
+keep
+gettp,12,ifnum=0,plnum=1,fdnum=0,cal=1 
+keep
+gettp,12,ifnum=0,plnum=0,fdnum=1,cal=0 
+keep
+gettp,12,ifnum=0,plnum=1,fdnum=0,cal=0 
+keep
+gettp,197,ifnum=0,plnum=0,fdnum=0,cal=1
+keep
+gettp,197,ifnum=0,plnum=0,fdnum=0,cal=0
+keep
+gettp,198,ifnum=0,plnum=0,fdnum=0,cal=1
+keep
+gettp,198,ifnum=0,plnum=0,fdnum=0,cal=0
+keep
+```


### PR DESCRIPTION
Fixes issue #553 by removing the check for Ka in the get methods, and instead switching the FDNUM labels on initialization of the `GBTFITSLoad` object.
There is also some refactoring done to reuse existing code.