### PR TITLE
Q8 test updates

### DIFF
--- a/src/dysh/coordinates/tests/test_coordinates_core.py
+++ b/src/dysh/coordinates/tests/test_coordinates_core.py
@@ -11,7 +11,13 @@ class TestCore:
         """Test the Observator class"""
         obs = Observatory()
         for k in ["alma", "Hat Creek", "La Silla Observatory", "Mars Hill", "Whipple"]:
-            assert obs[k] == EarthLocation.of_site(k)
+            # Try to get the observatory locations using the existing cache.
+            try:
+                eloc = EarthLocation.of_site(k)
+            # Force cache refresh if this fails.
+            except UnknownSiteException:
+                eloc = EarthLocation.of_site(k, refresh_cache=True)
+            assert obs[k] == eloc
         assert obs["GBT"] is GBT()  # instance method
         assert Observatory["GBT"] is GBT()  # static method
         try:

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -557,7 +557,8 @@ class TestGBTFITSLoad:
             g = gbtfitsload.GBTFITSLoad(f)
             for key, val in keyval.items():
                 _set = set([val])
-                g[key] = val
+                with pytest.warns(UserWarning):
+                    g[key] = val
                 assert set(g[key]) == _set
                 for sdf in g._sdf:
                     assert set(sdf[key]) == _set
@@ -572,10 +573,12 @@ class TestGBTFITSLoad:
             if "A6" in f.name:
                 g = gbtfitsload.GBTFITSLoad(out)
             else:
-                g = gbtfitsload.GBTFITSLoad(o)
+                with pytest.warns(UserWarning):
+                    g = gbtfitsload.GBTFITSLoad(o)
             for key, val in keyval.items():
                 _set = set([val])
-                g[key] = val
+                with pytest.warns(UserWarning):
+                    g[key] = val
                 assert set(g[key]) == _set
                 for sdf in g._sdf:
                     assert set(sdf[key]) == _set
@@ -588,7 +591,8 @@ class TestGBTFITSLoad:
             for key, val in keyval.items():
                 array = [val] * g.total_rows
                 _set = set([val])
-                g[key] = array
+                with pytest.warns(UserWarning):
+                    g[key] = array
                 assert set(g[key]) == _set
                 for sdf in g._sdf:
                     for b in sdf._bintable:
@@ -602,10 +606,12 @@ class TestGBTFITSLoad:
             if "A6" in f.name:
                 g = gbtfitsload.GBTFITSLoad(out)
             else:
-                g = gbtfitsload.GBTFITSLoad(o)
+                with pytest.warns(UserWarning):
+                    g = gbtfitsload.GBTFITSLoad(o)
             for key, val in keyval.items():
                 _set = set([val])
-                g[key] = val
+                with pytest.warns(UserWarning):
+                    g[key] = val
                 assert set(g[key]) == _set
                 for sdf in g._sdf:
                     assert set(sdf[key]) == _set
@@ -617,8 +623,10 @@ class TestGBTFITSLoad:
             g = gbtfitsload.GBTFITSLoad(f)
             for key, val in keyval.items():
                 array = [val] * 2 * g.total_rows
-                with pytest.raises(ValueError):
-                    g[key] = array
+                # This will warn and raise an error.
+                with pytest.warns(UserWarning):
+                    with pytest.raises(ValueError):
+                        g[key] = array
 
         # test that changed a previously selection column results in a warning
         g = gbtfitsload.GBTFITSLoad(files[0])
@@ -659,9 +667,10 @@ class TestGBTFITSLoad:
         new_path = tmp_path / "o"
         new_path.mkdir(parents=True)
         sdf_org = gbtfitsload.GBTFITSLoad(fits_path)
-        sdf_org["RADESYS"] = ""
-        sdf_org["CTYPE2"] = "AZ"
-        sdf_org["CTYPE3"] = "EL"
+        with pytest.warns(UserWarning):
+            sdf_org["RADESYS"] = ""
+            sdf_org["CTYPE2"] = "AZ"
+            sdf_org["CTYPE3"] = "EL"
 
         # Create a temporary directory and write the modified SDFITS.
         new_path = tmp_path / "o"
@@ -675,6 +684,7 @@ class TestGBTFITSLoad:
         # Test that we can create a `Spectrum` object.
         tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)
 
+    @pytest.mark.filterwarnings("ignore:Changing an existing SDFITS column")
     def test_hadec_coords(self, tmp_path):
         """
         Test that observations using HADec coordinates can produce a valid `Spectrum`.
@@ -685,8 +695,9 @@ class TestGBTFITSLoad:
         new_path = tmp_path / "o"
         new_path.mkdir(parents=True)
         sdf_org = gbtfitsload.GBTFITSLoad(fits_path)
-        sdf_org["RADESYS"] = ""
-        sdf_org["CTYPE2"] = "HA"
+        with pytest.warns(UserWarning):
+            sdf_org["RADESYS"] = ""
+            sdf_org["CTYPE2"] = "HA"
 
         # Create a temporary directory and write the modified SDFITS.
         new_path = tmp_path / "o"
@@ -700,6 +711,7 @@ class TestGBTFITSLoad:
         # Test that we can create a `Spectrum` object.
         tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0)[0].total_power(0)
 
+    @pytest.mark.filterwarnings("ignore:Changing an existing SDFITS column")
     def test_galactic_coords(self, tmp_path):
         """
         Test that observations using Galactic coordinates can produce a valid `Spectrum`.
@@ -710,9 +722,10 @@ class TestGBTFITSLoad:
         new_path = tmp_path / "o"
         new_path.mkdir(parents=True)
         sdf_org = gbtfitsload.GBTFITSLoad(fits_path)
-        sdf_org["RADESYS"] = ""
-        sdf_org["CTYPE2"] = "GLON"
-        sdf_org["CTYPE3"] = "GLAT"
+        with pytest.warns(UserWarning):
+            sdf_org["RADESYS"] = ""
+            sdf_org["CTYPE2"] = "GLON"
+            sdf_org["CTYPE3"] = "GLAT"
 
         # Create a temporary directory and write the modified SDFITS.
         new_path = tmp_path / "o"

--- a/src/dysh/fits/tests/test_sdfitsload.py
+++ b/src/dysh/fits/tests/test_sdfitsload.py
@@ -99,7 +99,8 @@ class TestSDFITSLoad:
         f = d / "AGBT18B_354_03/AGBT18B_354_03.raw.vegas/AGBT18B_354_03.raw.vegas.A.fits"
         g = SDFITSLoad(f)
         # all rows of a column to a single value
-        g["FREQRES"] = 1500.0  # Hz
+        with pytest.warns(UserWarning):
+            g["FREQRES"] = 1500.0  # Hz
         # test that the selection (index) was set
         assert list(set(g["FREQRES"]))[0] == 1500
         # test that the BinTableHDU data was set
@@ -107,13 +108,15 @@ class TestSDFITSLoad:
         # rows of a column to different values
         x = 3.1415 * np.arange(g.nrows(0), dtype=np.float64)
         # make sure lower/varying case also works
-        g["dopfreq"] = x
+        with pytest.warns(UserWarning):
+            g["dopfreq"] = x
         assert np.all(g["DoPFreQ"] == x)
         assert np.all(g._bintable[0].data["DOPFREQ"] == x)
         # Wrong length array (except single value which sets all rows) should raise ValueError.
         # We re-raise with additional context as Exception.
-        with pytest.raises(Exception):
-            g["TWARM"] = np.arange(g.nrows(0) + 99)
+        with pytest.warns(UserWarning):
+            with pytest.raises(Exception):
+                g["TWARM"] = np.arange(g.nrows(0) + 99)
 
         # File with multiple BinTableHDUs
         # This is a rare case and in any event the multiple bintables make likely  have
@@ -124,28 +127,33 @@ class TestSDFITSLoad:
         g = SDFITSLoad(f)
         # first test setting all rows to same value
         c = "MBM12"
-        g["OBJECT"] = c
+        with pytest.warns(UserWarning):
+            g["OBJECT"] = c
         assert np.all(g["object"] == c)
         assert np.all(g.bintable[0].data["OBJECT"] == c)
         assert np.all(g.bintable[1].data["OBJECT"] == c)
         # now an array
         c = ["NGC123"] * g.nrows(0) + ["3C111"] * g.nrows(1)
-        g["object"] = c
+        with pytest.warns(UserWarning):
+            g["object"] = c
         assert np.all(g["object"] == c)
         assert np.all(g.bintable[0].data["OBJECT"] == c[0 : g.nrows(0)])
         assert np.all(g.bintable[1].data["OBJECT"] == c[g.nrows(0) :])
         c.append("ONETOOMANY")
-        with pytest.raises(Exception):
-            g["object"] = c
+        with pytest.warns(UserWarning):
+            with pytest.raises(Exception):
+                g["object"] = c
         # now a number
         num = 1.23e9
-        g["RESTFREQ"] = num
+        with pytest.warns(UserWarning):
+            g["RESTFREQ"] = num
         assert np.all(g["restfreq"] == num)
         assert np.all(g.bintable[0].data["RESTFREQ"] == num)
         assert np.all(g.bintable[1].data["RESTFREQ"] == num)
         # now a sequence of numbers
         num = np.arange(8) * 9.0e9
-        g["RESTFREQ"] = num
+        with pytest.warns(UserWarning):
+            g["RESTFREQ"] = num
         assert np.all(g["restfreq"] == num)
         assert np.all(g.bintable[0].data["restfreq"] == num[0 : g.nrows(0)])  # wow astropy allows lowercase
         assert np.all(g.bintable[1].data["restfreq"] == num[g.nrows(0) :])
@@ -214,7 +222,8 @@ class TestSDFITSLoad:
             assert np.all(g.bintable[0].data[k] == v)
         with pytest.raises(Exception):
             c.append("nope")
-            g["robin"] = c
+            with pytest.warns(UserWarning):
+                g["robin"] = c
         c = ["boy wonder"] * g.nrows(0)
         colval["robin"] = c
         # write and check
@@ -240,7 +249,8 @@ class TestSDFITSLoad:
         #    assert np.all(g.bintable[1].data[k] == v)
         with pytest.raises(Exception):
             c.append("nope")
-            g["robin"] = c
+            with pytest.warns(UserWarning):
+                g["robin"] = c
         c = ["boy wonder"] * g.total_rows
         colval["robin"] = c
 
@@ -249,21 +259,24 @@ class TestSDFITSLoad:
         d = util.get_project_testdata()
         f = d / "AGBT18B_354_03/AGBT18B_354_03.raw.vegas/AGBT18B_354_03.raw.vegas.A.fits"
         g = SDFITSLoad(f)
-        g.delete_column("dopfreq")
+        with pytest.warns(UserWarning):
+            g.delete_column("dopfreq")
         assert "DOPFREQ" not in g.columns
         assert "DOPFREQ" not in g._bintable[0].data.names
 
         # File with multiple BinTableHDUs
         f = d / "TGBT17A_506_11/TGBT17A_506_11.raw.vegas.A_truncated_rows.fits"
         g = SDFITSLoad(f)
-        g.delete_column("TWARM")
+        with pytest.warns(UserWarning):
+            g.delete_column("TWARM")
         assert "TWARM" not in g.columns
         for b in g._bintable:
             assert "TWARM" not in b.data.names
 
         # DATA columns can't be deleted
-        with pytest.raises(Exception):
-            g.delete_column("dAtA")
+        with pytest.warns(UserWarning):
+            with pytest.raises(Exception):
+                g.delete_column("dAtA")
 
     def test_data_access(self):
         """test getting and setting the DATA column of SDFITS"""
@@ -273,7 +286,8 @@ class TestSDFITSLoad:
         g = SDFITSLoad(f)
         data = g["DATA"]
         assert data.shape == (32, 131072)
-        g["DATA"] = np.zeros([32, 131072])
+        with pytest.warns(UserWarning):
+            g["DATA"] = np.zeros([32, 131072])
         assert np.all(g["DATA"] == 0)
         # test some slicing
         assert np.shape(g["DATA"][:, 0:10]) == (32, 10)
@@ -287,8 +301,9 @@ class TestSDFITSLoad:
         # The binary tables have different shapes, so setting and getting is not allowed.
         with pytest.raises(Exception):
             g["DATA"]
-        with pytest.raises(Exception):
-            g["DATA"] = np.random.rand(1024)
+        with pytest.warns(UserWarning):
+            with pytest.raises(Exception):
+                g["DATA"] = np.random.rand(1024)
 
     def test_udata(self):
         """Test that `udata` is working."""


### PR DESCRIPTION
This PR:
* Fixes (?) a potential issue with one of the tests for the `Observatory` class (`astropy` recommends refreshing the cache if an observatory could not be found -- which we saw at least once recently).
* Checks for `UserWarning` in tests that involve modifying SDFITS columns. Mainly to clean up the output of the tests.