### PR TITLE
Specplot selection update

### DIFF
--- a/src/dysh/__init__.py
+++ b/src/dysh/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for dysh."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 all = ["version"]
 

--- a/src/dysh/coordinates/core.py
+++ b/src/dysh/coordinates/core.py
@@ -747,3 +747,16 @@ def hor2eq(az, alt, frame, date_obs, unit="deg", location=GBT()):
 
     altaz = coord.SkyCoord(az=az, alt=alt, unit=unit, frame="altaz", obstime=Time(date_obs), location=location)
     return altaz.transform_to(astropy_frame_dict[frame])
+
+
+def ra2ha(lst, ra):
+    """
+    Take LST (sec) and RA (deg) and output wrapped HA (hr).
+    Follows GBTIDL implementation (with the hour conversion included)
+    """
+    ha = np.around(15 * (lst / 3600) - ra, 2)
+    if ha > 180:
+        ha -= 360
+    elif ha < -180:
+        ha += 360
+    return np.around(ha / 15, 2)

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -117,7 +117,7 @@ class SpectrumPlot:
         """The underlying `~spectra.spectrum.Spectrum`"""
         return self._spectrum
 
-    def plot(self, show_header=True, select=True, **kwargs):
+    def plot(self, show_header=True, select=True, show=True, **kwargs):
         # @todo document kwargs here
         r"""
         Plot the spectrum.
@@ -129,7 +129,8 @@ class SpectrumPlot:
         **kwargs : various
             keyword=value arguments (need to describe these in a central place)
         """
-        plt.ion()
+        if show:
+            plt.ion()
         plt.rcParams["font.family"] = "monospace"
         # plt.rcParams['axes.formatter.useoffset'] = False # Disable use of offset.
 
@@ -216,7 +217,8 @@ class SpectrumPlot:
             self._selector = InteractiveSpanSelector(self._axis)
             self._spectrum._selection = self._selector.get_selected_regions()
 
-        self.refresh()
+        if show:
+            self.refresh()
 
     def reset(self):
         """Reset the plot keyword arguments to their defaults."""

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -14,7 +14,13 @@ from astropy.utils.masked import Masked
 from matplotlib.patches import Rectangle
 from matplotlib.widgets import Button, SpanSelector
 
-from ..coordinates import Observatory, crval4_to_pol, decode_veldef, frame_to_label
+from ..coordinates import (
+    Observatory,
+    crval4_to_pol,
+    decode_veldef,
+    frame_to_label,
+    ra2ha,
+)
 
 _KMS = u.km / u.s
 
@@ -332,18 +338,6 @@ class SpectrumPlot:
             out_dec = out_str[12:]
             return out_ra, out_dec
 
-        def ra2ha(lst, ra):
-            """
-            Take LST (sec) and RA (deg) and output wrapped HA (hr).
-            Follows GBTIDL implementation (with the hour conversion included)
-            """
-            ha = np.around(15 * (lst / 3600) - ra, 2)
-            if ha > 180:
-                ha -= 360
-            elif ha < -180:
-                ha += 360
-            return np.around(ha / 15, 2)
-
         # col 1
         self._axis.annotate(f"Scan     {s.meta['SCAN']}", (hcoords[0], vcoords[0]), xycoords=xyc, size=fsize_small)
         self._axis.annotate(f"{s.meta['DATE-OBS'][:10]}", (hcoords[0], vcoords[1]), xycoords=xyc, size=fsize_small)
@@ -430,9 +424,7 @@ class SpectrumPlot:
     def refresh(self):
         """Refresh the plot"""
         if self.axis is not None:
-            self.axis.figure.canvas.draw()
-            # self.axis.figure.canvas.draw_idle()
-            # self._plt.show()
+            self.axis.figure.canvas.draw_idle()
 
     def savefig(self, file, **kwargs):
         r"""Save the plot
@@ -454,15 +446,6 @@ class SpectrumPlot:
         regions = self._selector.get_selected_regions()
         return [tuple(np.sort([np.argmin(abs(p - self._sa.value)) for p in r])) for r in regions]
 
-    # def next(self, event):
-    #     "test button. puts a funny note on the plot when pressed."
-    #     fsize_small = 9
-    #     xyc = "figure fraction"
-    #     print(event)
-    #     print('test')
-    #     self._axis.annotate("oh hi there", (0.5, 0.5), xycoords=xyc, size=fsize_small)
-    #     self.refresh()
-
 
 class InteractiveSpanSelector:
     def __init__(self, ax):
@@ -472,7 +455,12 @@ class InteractiveSpanSelector:
         self.active_patch = None
         self.press = None
         self.dragging_edge = None
-        self.edge_threshold = 0.02  # in axes fraction
+        self.edge_threshold = 0.03  # in axes fraction
+        self.colors = {
+            "edge": (0, 0, 0, 1),
+            "face": (0, 0, 0, 0.3),
+            "edge_selected": plt.matplotlib.colors.to_rgb("#6c3483") + (1.0,),
+        }
 
         # SpanSelector for creating new regions.
         self.span = SpanSelector(
@@ -481,7 +469,7 @@ class InteractiveSpanSelector:
             direction="horizontal",
             useblit=True,
             interactive=False,
-            props=dict(alpha=0.3, facecolor="tab:gray"),
+            props=dict(facecolor=self.colors["face"], alpha=0.3),
         )
 
         # Button to clear all selections.
@@ -489,10 +477,16 @@ class InteractiveSpanSelector:
         self.clear_button = Button(self.button_ax, "Clear Regions")
         self.clear_button.on_clicked(self.clear_regions)
 
+        # Button to clear a single region.
+        self.button2_ax = self.canvas.figure.add_axes([0.24, 0.025, 0.12, 0.04])
+        self.del_button = Button(self.button2_ax, "Delete Region")
+        self.del_button.on_clicked(self.clear_region)
+
         # Connect interaction events for dragging/resizing
         self.cid_press = self.canvas.mpl_connect("button_press_event", self.on_press)
         self.cid_release = self.canvas.mpl_connect("button_release_event", self.on_release)
         self.cid_motion = self.canvas.mpl_connect("motion_notify_event", self.on_motion)
+        self.cid_key = plt.gcf().canvas.mpl_connect("key_press_event", self.on_key_press)
 
     def onselect(self, vmin, vmax):
         if abs(vmax - vmin) < 1e-6:
@@ -502,9 +496,8 @@ class InteractiveSpanSelector:
             vmax - vmin,
             1,
             transform=self.ax.get_xaxis_transform(),
-            facecolor="tab:gray",
-            alpha=0.3,
-            edgecolor="black",
+            facecolor=self.colors["face"],
+            edgecolor=self.colors["edge"],
         )
         self.ax.add_patch(rect)
         self.regions.append(rect)
@@ -513,22 +506,28 @@ class InteractiveSpanSelector:
     def on_press(self, event):
         if event.inaxes != self.ax:
             return
+        got_one = False
         for patch in self.regions:
             contains, attr = patch.contains(event)
-            if contains:
+            if contains and not got_one:
                 self.span.set_active(False)
                 x0 = patch.get_x()
                 x1 = x0 + patch.get_width()
                 xtol = self.edge_threshold * (self.ax.get_xlim()[1] - self.ax.get_xlim()[0])
-                if abs(event.xdata - x0) < xtol:
+                if abs(event.xdata - x0) <= xtol or abs(event.xdata + x0) <= xtol:
                     self.dragging_edge = "left"
-                elif abs(event.xdata - x1) < xtol:
+                elif abs(event.xdata - x1) <= xtol or abs(event.xdata + x1) <= xtol:
                     self.dragging_edge = "right"
                 else:
                     self.dragging_edge = "move"
                 self.active_patch = patch
                 self.press = event.xdata, x0, x1
-                break
+                self.active_patch.set_edgecolor(self.colors["edge_selected"])
+                self.active_patch.set_linewidth(2.0)
+                got_one = True
+            else:
+                patch.set_edgecolor(self.colors["edge"])
+                patch.set_linewidth(1.0)
 
     def on_motion(self, event):
         if not self.active_patch or event.inaxes != self.ax or self.press is None:
@@ -550,16 +549,30 @@ class InteractiveSpanSelector:
         self.canvas.draw_idle()
 
     def on_release(self, event):
-        self.active_patch = None
         self.press = None
         self.dragging_edge = None
         self.span.set_active(True)
+
+    def on_key_press(self, event):
+        if event.key == "d":
+            self.clear_region(event)
+        if event.key == "D":
+            self.clear_regions(event)
 
     def clear_regions(self, event=None):
         for patch in self.regions:
             patch.remove()
         self.regions.clear()
-        self.canvas.draw()
+        self.canvas.draw_idle()
+
+    def clear_region(self, event=None):
+        if not self.active_patch:
+            return
+        idx = self.regions.index(self.active_patch)
+        self.regions.remove(self.active_patch)
+        self.active_patch.remove()
+        self.active_patch = None
+        self.canvas.draw_idle()
 
     def get_selected_regions(self):
         return [(patch.get_x(), patch.get_x() + patch.get_width()) for patch in self.regions]

--- a/src/dysh/plot/tests/test_specplot.py
+++ b/src/dysh/plot/tests/test_specplot.py
@@ -1,7 +1,6 @@
 """Tests for specplot."""
 
 from pathlib import Path
-from unittest.mock import patch
 
 from dysh.fits import GBTFITSLoad
 from dysh.util import get_project_testdata
@@ -10,20 +9,25 @@ from dysh.util import get_project_testdata
 class TestSpecplot:
     """ """
 
-    @patch("dysh.plot.specplot.plt.show")
-    def test_savefig(self, mock_show, tmp_path):
+    def test_savefig(self, tmp_path):
         """
         Test that plots are saved.
         """
+
+        # Disable interactive plotting.
+        import matplotlib.pyplot as plt
+
+        plt.ioff()
+
         p = get_project_testdata()
         sdf = GBTFITSLoad(p / "AGBT20B_014_03.raw.vegas/AGBT20B_014_03.raw.vegas.A6.fits")
         tp = sdf.gettp(scan=6, plnum=0, ifnum=0, fdnum=0).timeaverage()
-        tp.plot()
+        tp.plot(show=False)
         of = tmp_path / "test_savefig.png"
         tp.savefig(of)
         assert of.is_file()
 
-        tp.plot(show_header=False)
+        tp.plot(show_header=False, show=False)
         of = tmp_path / "test_savefig_noheader.png"
         tp.savefig(of)
         assert of.is_file()

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1,5 +1,4 @@
 import warnings
-from unittest.mock import patch
 
 import astropy.units as u
 import numpy as np
@@ -254,12 +253,17 @@ class TestSpectrum:
         print(s.comments)
         assert "I removed a baseline" in s.comments
 
-    @patch("dysh.plot.specplot.plt.show")
-    def test_slice(self, mock_show, tmp_path):
+    def test_slice(self, tmp_path):
         """
         Test that we can slice a `Spectrum` using channels or units.
         For units we only consider frequencies for now.
         """
+
+        # Disable interactive plotting.
+        import matplotlib.pyplot as plt
+
+        plt.ioff()
+
         meta_ignore = ["CRPIX1", "CRVAL1"]
         spec_pars = ["_target", "_velocity_frame", "_observer", "_obstime"]
         s = slice(1000, 1100, 1)
@@ -279,7 +283,7 @@ class TestSpectrum:
         for k in spec_pars:
             assert vars(trimmed)[k] == vars(self.ps0)[k]
         # Check that we can plot.
-        trimmed.plot(xaxis_unit="km/s", yaxis_unit="mK", vel_frame="itrs")
+        trimmed.plot(xaxis_unit="km/s", yaxis_unit="mK", vel_frame="itrs", show=False)
         # Check that we can write.
         o = tmp_path / "sub"
         o.mkdir()
@@ -302,7 +306,7 @@ class TestSpectrum:
                 assert trimmed_nu.meta[k] == v
         for k in spec_pars:
             assert vars(trimmed_nu)[k] == vars(self.ps0)[k]
-        trimmed_nu.plot(xaxis_unit="km/s", yaxis_unit="mK")
+        trimmed_nu.plot(xaxis_unit="km/s", yaxis_unit="mK", show=False)
 
         # km/s.
         spec_ax = self.ps0.spectral_axis.to("km/s")
@@ -314,7 +318,7 @@ class TestSpectrum:
                 assert trimmed_vel.meta[k] == v
         for k in spec_pars:
             assert vars(trimmed_vel)[k] == vars(self.ps0)[k]
-        trimmed_vel.plot(xaxis_unit="MHz", yaxis_unit="mK")
+        trimmed_vel.plot(xaxis_unit="MHz", yaxis_unit="mK", show=False)
 
         # m.
         spec_ax = self.ps0.spectral_axis.to("m")

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -736,3 +736,31 @@ class TestSpectrum:
             data=np.arange(64) * u.K, meta=meta, use_wcs=True, observer_location=Observatory["GBT"]
         )
         assert s.meta["RADESYS"] == meta["RADECSYS"]
+
+    def test_get_selected_regions(self):
+        """
+        * Test that get selected regions raises TypeError if no plotter is found.
+        * Test that the returned selection is in the expected format.
+        """
+
+        s = Spectrum.fake_spectrum()
+        with pytest.raises(TypeError) as excinfo:
+            s.get_selected_regions()
+        assert excinfo.type is TypeError
+
+        # Plot and add a region.
+        import matplotlib.pyplot as plt
+
+        plt.ioff()
+        s.plot(show=False, xaxis_unit="MHz")
+        s._plotter._selector.onselect(1402.3, 1402.5)
+        r = s.get_selected_regions()
+        assert r == [(574, 853)]
+
+        # Now with units.
+        r_nu = s.get_selected_regions(unit="MHz")
+        assert r_nu[0][0].value == pytest.approx(1402.3)
+        assert r_nu[0][1].value == pytest.approx(1402.5)
+        r_v = s.get_selected_regions(unit="km/s")
+        assert r_v[0][0].value == pytest.approx(3870.69160846)
+        assert r_v[0][1].value == pytest.approx(3827.48453869)


### PR DESCRIPTION
This PR:
* Adds buttons and key strokes to delete one or all regions. You can delete all regions with `D` and a single region with `d` -- Issue #571 . 
* Add support for units in `Spectrum.get_selected_region()` -- Issue #572 .
* Fix issue #532 .
