### PR TITLE
reset patch number after minor version bump

### DIFF
--- a/src/dysh/__init__.py
+++ b/src/dysh/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for dysh."""
 
-__version__ = "0.5.5"
+__version__ = "0.5.0"
 
 all = ["version"]
 


### PR DESCRIPTION
The path number should be reset after bumping the minor version. Similarly, when bumping the major version, the minor and patch should be reset. Source: https://semver.org/#semantic-versioning-specification-semver