### PR TITLE
docs: update read the docs workflow to use uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,13 +7,17 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-    os: ubuntu-22.04
+    os: ubuntu-24.04
     tools:
         python: "3.10"
-        # You can also specify other tool versions:
-        # nodejs: "19"
-        # rust: "1.64"
-        # golang: "1.19"
+    jobs:
+        create_environment:
+            - asdf plugin add uv
+            - asdf install uv latest
+            - asdf global uv latest
+            - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync
+        install:
+            - "true"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -22,10 +26,3 @@ sphinx:
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
 #    - pdf
-
-# Optionally declare the Python requirements required to build your docs
-python:
-    install:
-        - requirements: requirements.txt
-        - method: pip
-          path: .


### PR DESCRIPTION
After we removed the `requirements.txt` file our read the docs builds have been failing. This PR updates the read the docs workflow to use `uv` based on this: https://github.com/astral-sh/uv/issues/10074

I tested the results on a separate read the docs instance, and the changes fix the issue:
https://dysh-test.readthedocs.io/en/rtd-uv/tutorials/examples/hi_survey.html