### PR TITLE
fix: issue #649

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -39,7 +39,7 @@ from ..util import (
     eliminate_flagged_rows,
     keycase,
     select_from,
-    show_DataFrame,
+    show_dataframe,
     uniq,
 )
 from ..util.files import dysh_data
@@ -427,17 +427,16 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         #
         # @todo perhaps return as a astropy.Table then we can have units
         """
-        Create a summary of the input dataset.
-        If `verbose=False` (default), some numeric data
-        (e.g., RESTFREQ, AZIMUTH, ELEVATIO) are
-        averaged over the records with the same scan number.
+        Create a summary of the input dataset as a pandas DataFrame.
 
         Parameters
         ----------
         scan : int or 2-tuple
             The scan(s) to use. A 2-tuple represents (beginning, ending) scans. Default: show all scans
         verbose: bool
-            If True, list every record, otherwise return a compact summary.
+            If `verbose=False` (default), some numeric data (e.g., RESTFREQ, AZIMUTH, ELEVATIO) are
+            averaged over the records with the same scan number.
+            If True, no averaging is done and additional columns are added to the output.
 
         Returns
         -------
@@ -571,8 +570,10 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         verbose : bool
             If True, list every record, otherwise return a compact summary.
         max_rows : int or None
-            Maximum number of rows to display. If not provided or -1, it will use the
-            value found in the dysh configuration file for summary_max_rows.
+            Maximum number of rows to display. If less than the total number of rows, then
+            the first `max_rows/2` and last `max_rows/2` rows will be shown, separated
+            by ellipsis. If set to -1 (Default), the
+            value found in the dysh configuration file for `summary_max_rows` will be used.
             Set to `None` for unlimited rows.
         show_index : bool
             Show index of the `~pandas.DataFrame`.
@@ -585,7 +586,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         max_cols = 1500
         width = 1500
 
-        show_DataFrame(compressed_df, show_index=show_index, max_rows=max_rows, max_cols=max_cols, width=width)
+        show_dataframe(compressed_df, show_index=show_index, max_rows=max_rows, max_cols=max_cols, width=width)
 
     def velocity_convention(self, veldef):
         """Given the GBT VELDEF FITS string return the specutils

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -427,13 +427,13 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         #
         # @todo perhaps return as a astropy.Table then we can have units
         """
-        Create a summary of the input dataset as a pandas DataFrame.
+        Create a summary of the input dataset as a `~pandas.DataFrame`.
 
         Parameters
         ----------
         scan : int or 2-tuple
             The scan(s) to use. A 2-tuple represents (beginning, ending) scans. Default: show all scans
-        verbose: bool
+        verbose : bool
             If `verbose=False` (default), some numeric data (e.g., RESTFREQ, AZIMUTH, ELEVATIO) are
             averaged over the records with the same scan number.
             If True, no averaging is done and additional columns are added to the output.
@@ -555,7 +555,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
 
     def summary(self, scan=None, verbose=False, max_rows=-1, show_index=False):
         """
-        Create a summary of the `~dysh.fits.GBTFITSLoad` object..
+        Create a summary of the `~dysh.fits.GBTFITSLoad` object.
         If `verbose=False` (default), some numeric data
         (e.g., RESTFREQ, AZIMUTH, ELEVATIO) are
         averaged over the records with the same scan number.
@@ -572,9 +572,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         max_rows : int or None
             Maximum number of rows to display. If less than the total number of rows, then
             the first `max_rows/2` and last `max_rows/2` rows will be shown, separated
-            by ellipsis. If set to -1 (Default), the
-            value found in the dysh configuration file for `summary_max_rows` will be used.
-            Set to `None` for unlimited rows.
+            by ellipsis. If set to -1 (Default), the value found in the dysh configuration
+            file for `summary_max_rows` will be used. Set to `None` for unlimited rows.
         show_index : bool
             Show index of the `~pandas.DataFrame`.
         """
@@ -584,9 +583,8 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
         if max_rows == -1:
             max_rows = conf.summary_max_rows
         max_cols = 1500
-        width = 1500
 
-        show_dataframe(compressed_df, show_index=show_index, max_rows=max_rows, max_cols=max_cols, width=width)
+        show_dataframe(compressed_df, show_index=show_index, max_rows=max_rows, max_cols=max_cols)
 
     def velocity_convention(self, veldef):
         """Given the GBT VELDEF FITS string return the specutils

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -540,7 +540,7 @@ def in_notebook() -> bool:
     return True
 
 
-def show_DataFrame(df, show_index=False, max_rows=None, max_cols=None, width=None):
+def show_dataframe(df, show_index=False, max_rows=None, max_cols=None, width=None):
     """
     Function to show a `~pandas.DataFrame` in IPython or Jupyter.
 

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Union
 
 import numpy as np
-import pandas as pd
 from astropy.time import Time
 from astropy.units.quantity import Quantity
 from IPython.display import HTML, display
@@ -540,7 +539,7 @@ def in_notebook() -> bool:
     return True
 
 
-def show_dataframe(df, show_index=False, max_rows=None, max_cols=None, width=None):
+def show_dataframe(df, show_index=False, max_rows=None, max_cols=None):
     """
     Function to show a `~pandas.DataFrame` in IPython or Jupyter.
 
@@ -554,23 +553,10 @@ def show_dataframe(df, show_index=False, max_rows=None, max_cols=None, width=Non
         Maximum number of rows to display.
     max_cols : int or None
         Maximum number of columns to display.
-    width : int or None
-        Display width. Only used if `show_index=True`.
     """
 
-    # If we do not hide the index, not much to be done.
-    # Both IPython and Jupyter can use the same function
-    # and we can display the DataFrame directly.
-    if show_index:
-        with pd.option_context("display.max_rows", max_rows, "display.max_columns", max_cols, "display.width", width):
-            display(df)
+    kwargs = {"max_rows": max_rows, "max_cols": max_cols, "index": show_index}
+    if in_notebook():
+        display(HTML(df.to_html(**kwargs)))
     else:
-        # If we want to hide the index, we have to use a pandas.Styler object.
-        # These are not affected with pd.set_option or pd.option_context,
-        # so we have to create an HTML or string representation and provide
-        # the relevant options directly (e.g., max_rows).
-        # In IPython we cannot display the string, as it would ignore line breaks.
-        if in_notebook():
-            display(HTML(df.style.hide(axis="index").to_html(max_rows=max_rows, max_columns=max_cols)))
-        else:
-            print(df.to_string(index=False, max_rows=max_rows, max_cols=max_cols))
+        print(df.to_string(**kwargs))


### PR DESCRIPTION
Split summary into two functions summary and get_summary. get_summary does the heavy lifting of creating the DataFrame. summary now calls get_summary and displays the result using dysh.util.core.show_DataFrame. This will show the summary even if the call is not the last one in a cell.
It also adds an argument for the maximum number of rows and hides the index by default.