### PR TITLE
dysh_data_url

### DIFF
--- a/src/dysh/shell/shell.py
+++ b/src/dysh/shell/shell.py
@@ -73,6 +73,7 @@ def init_shell(
     from astropy.table import Table
 
     from dysh.fits.gbtfitsload import GBTFITSLoad, GBTOffline, GBTOnline
+    from dysh.util.files import dysh_data
 
     user_ns = {
         "pd": pd,
@@ -80,6 +81,7 @@ def init_shell(
         "GBTFITSLoad": GBTFITSLoad,
         "GBTOnline": GBTOnline,
         "GBTOffline": GBTOffline,
+        "dysh_data": dysh_data,
         "Table": Table,
         "fits": fits,
     }

--- a/src/dysh/util/files.py
+++ b/src/dysh/util/files.py
@@ -175,6 +175,10 @@ def dysh_data(sdfits=None, test=None, example=None, accept=None, dysh_data=None,
     if verbose:
         print("DYSH_DATA:", dysh_data)
 
+    # Override the default _url.
+    if "DYSH_DATA_URL" in os.environ:
+        _url = os.environ["DYSH_DATA_URL"]
+
     # 2. Process whichever one of 'sdfits=', 'test=', 'example=', and  'accept=' is present (in that order)
 
     # sdfits:   the main place where GBO data reside


### PR DESCRIPTION
Add DYSH_DATA_URL as a system variable to be used by `dysh_data`. It overrides the default url.