### PR TITLE
Fix issue 613

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -267,6 +267,9 @@ nb_execution_mode = "cache"
 # Use this mode if working on the documentation with sphinx-autobuild.
 # nb_execution_mode = "auto"
 
+# Execution timeout.
+# -1 should set this to no limit.
+nb_execution_timeout = -1
 
 # Where to store the notebook cache
 nb_execution_cache_path = "jupyter_cache"


### PR DESCRIPTION
fix: issue #613
Set execution timeout to no limit

The issue seems to have gone away in the latest build of RtD. Can it hurt to add this?