### PR TITLE
Issue #360

### DIFF
--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -1411,6 +1411,21 @@ class Spectrum(Spectrum1D, HistoricalBase):
         else:
             raise NotImplementedError("Use a slice for slicing.")
 
+        # WCS slicing does not do well if the start is negative.
+        if start is not None and not isinstance(start, u.Quantity) and start < 0:
+            start_idx = len(self.data) + start
+
+        # Sort the start and stop indices if they are not None nor
+        # negative integers.
+        if (
+            start is not None
+            and stop is not None
+            and not (
+                (not isinstance(start, u.Quantity) and start < 0) or (not isinstance(stop, u.Quantity) and stop < 0)
+            )
+        ):
+            start_idx, stop_idx = np.sort([start_idx, stop_idx])
+
         # Slicing uses NumPY ordering by default.
         sliced_wcs = wcs[0:1, 0:1, 0:1, start_idx:stop_idx]
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -266,15 +266,18 @@ class TestSpectrum:
 
         plt.ioff()
 
+        # General variables.
         meta_ignore = ["CRPIX1", "CRVAL1"]
         spec_pars = ["_target", "_velocity_frame", "_observer", "_obstime"]
         s = slice(1000, 1100, 1)
+        tol = 1e-5  # Tolerance to compare spectral axes.
+
         trimmed = self.ps0[s]
         assert trimmed.flux[0] == self.ps0.flux[s.start]
         assert trimmed.flux[-1] == self.ps0.flux[s.stop - 1]
         assert np.all(trimmed.flux == self.ps0.flux[s])
         # The slicing changes the values at the micro Hz level.
-        assert np.all(trimmed.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
+        assert np.all(trimmed.spectral_axis.value - self.ps0.spectral_axis[s].value < tol)
         # Check meta values. The trimmed spectrum has an additional
         # key: 'original_wcs'.
         for k, v in self.ps0.meta.items():
@@ -302,7 +305,7 @@ class TestSpectrum:
         spec_ax = self.ps0.spectral_axis
         trimmed_nu = self.ps0[spec_ax[s.start].to("Hz") : spec_ax[s.stop].to("Hz")]
         assert np.all(trimmed_nu.flux == self.ps0.flux[s])
-        assert np.all(trimmed_nu.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
+        assert np.all(trimmed_nu.spectral_axis.value - self.ps0.spectral_axis[s].value < tol)
         for k, v in self.ps0.meta.items():
             if k not in meta_ignore:
                 assert trimmed_nu.meta[k] == v
@@ -314,7 +317,7 @@ class TestSpectrum:
         spec_ax = self.ps0.spectral_axis.to("km/s")
         trimmed_vel = self.ps0[spec_ax[s.start] : spec_ax[s.stop]]
         assert np.all(trimmed_vel.flux == self.ps0.flux[s])
-        assert np.all(trimmed_vel.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
+        assert np.all(trimmed_vel.spectral_axis.value - self.ps0.spectral_axis[s].value < tol)
         for k, v in self.ps0.meta.items():
             if k not in meta_ignore:
                 assert trimmed_vel.meta[k] == v
@@ -326,7 +329,73 @@ class TestSpectrum:
         spec_ax = self.ps0.spectral_axis.to("m")
         trimmed_wav = self.ps0[spec_ax[s.start] : spec_ax[s.stop]]
         assert np.all(trimmed_wav.flux == self.ps0.flux[s])
-        assert np.all(trimmed_wav.spectral_axis.value - self.ps0.spectral_axis[s].value < 1e-5)
+        assert np.all(trimmed_wav.spectral_axis.value - self.ps0.spectral_axis[s].value < tol)
+
+        # Slice in any order.
+        # int.
+        trimmed_sp = self.ps0[s]
+        trimmed_sp_inv = self.ps0[s.stop : s.start]
+        assert np.all(trimmed_sp.flux == trimmed_sp_inv.flux)
+        assert np.all(trimmed_sp.spectral_axis.value - trimmed_sp_inv.spectral_axis.value < tol)
+
+        # Hz.
+        spec_ax = self.ps0.spectral_axis
+        trimmed_nu = self.ps0[spec_ax[s.start].to("Hz") : spec_ax[s.stop].to("Hz")]
+        trimmed_nu_inv = self.ps0[spec_ax[s.stop].to("Hz") : spec_ax[s.start].to("Hz")]
+        assert np.all(trimmed_nu.flux == trimmed_nu_inv.flux)
+        assert np.all(trimmed_nu.spectral_axis.value - trimmed_nu_inv.spectral_axis.value < tol)
+
+        # km/s.
+        spec_ax = self.ps0.spectral_axis.to("km/s")
+        trimmed_vel = self.ps0[spec_ax[s.start] : spec_ax[s.stop]]
+        trimmed_vel_inv = self.ps0[spec_ax[s.stop] : spec_ax[s.start]]
+        assert np.all(trimmed_vel.flux == trimmed_vel_inv.flux)
+        assert np.all(trimmed_vel.spectral_axis.value - trimmed_vel_inv.spectral_axis.value < tol)
+
+        # m.
+        spec_ax = self.ps0.spectral_axis.to("m")
+        trimmed_wav = self.ps0[spec_ax[s.start] : spec_ax[s.stop]]
+        trimmed_wav_inv = self.ps0[spec_ax[s.stop] : spec_ax[s.start]]
+        assert np.all(trimmed_wav.flux == trimmed_wav_inv.flux)
+        assert np.all(trimmed_wav.spectral_axis.value - trimmed_wav_inv.spectral_axis.value < tol)
+
+        # Slice using negative values.
+        ns = slice(10, -10)
+        trimmed_sp = self.ps0[ns]
+        assert np.all(trimmed_sp.flux == self.ps0.flux[ns])
+        assert np.all((trimmed_sp.spectral_axis.quantity - self.ps0.spectral_axis.quantity[ns]).value < tol)
+
+        # km/s.
+        spec_ax = self.ps0.spectral_axis.to("km/s")
+        trimmed_vel = self.ps0[spec_ax[ns.start] : ns.stop]
+        assert np.all(trimmed_vel.flux == self.ps0.flux[ns])
+        assert np.all((trimmed_vel.spectral_axis.quantity - self.ps0.spectral_axis.quantity[ns]).value < tol)
+
+        # Both start and stop are negative values.
+        ns = slice(-100, -10)
+        trimmed_sp = self.ps0[ns]
+        assert np.all(trimmed_sp.flux == self.ps0.flux[ns])
+        assert np.all((trimmed_sp.spectral_axis.quantity - self.ps0.spectral_axis.quantity[ns]).value < tol)
+
+        # km/s.
+        spec_ax = self.ps0.spectral_axis.to("km/s")
+        trimmed_vel = self.ps0[spec_ax[ns.start] : ns.stop]
+        assert np.all(trimmed_vel.flux == self.ps0.flux[ns])
+        assert np.all((trimmed_vel.spectral_axis.quantity - self.ps0.spectral_axis.quantity[ns]).value < tol)
+
+        # Negative start and no stop.
+        s = slice(-100, None)
+        trimmed_sp = self.ps0[s]
+        assert len(trimmed_sp.data) == 100
+        assert np.all(trimmed_sp.flux == self.ps0.flux[s])
+        assert np.all((trimmed_sp.spectral_axis.quantity - self.ps0.spectral_axis.quantity[s]).value < tol)
+
+        # Negative stop and no start.
+        s = slice(None, -100)
+        trimmed_sp = self.ps0[s]
+        assert len(trimmed_sp.data) == len(self.ps0.data) - 100
+        assert np.all(trimmed_sp.flux == self.ps0.flux[s])
+        assert np.all((trimmed_sp.spectral_axis.quantity - self.ps0.spectral_axis.quantity[s]).value < tol)
 
     def test_smooth(self):
         """Test for smooth with `decimate=0`"""


### PR DESCRIPTION
fix: issue #360 spectrum slicing order

It should now be possible to slice using negative values, or quantities in any order. If the start is negative, it will be cast into a positive value (astropy issue). If the start and stop are not negative, they will be sorted before slicing the underlying objects.