### PR TITLE
remove confusing message about "calibrating again"

### DIFF
--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -1339,8 +1339,6 @@ class TPScan(ScanBase):
         """Calibrate the total power data according to the CAL/SIG table above"""
         # the way the data are formed depend only on cal state
         # since we have downselected based on sig state in the constructor
-        if self._calibrated is not None:
-            logger.warning(f"Scan {self.scan} was previously calibrated. Calibrating again.")
         if self.calstate is None:
             self._calibrated = (0.5 * (self._refcalon + self._refcaloff)).astype(float)
         elif self.calstate:
@@ -1651,8 +1649,6 @@ class PSScan(ScanBase):
         kwargs_opts.update(kwargs)
         if self._smoothref > 1 and kwargs_opts["verbose"]:
             logger.debug(f"PSScan smoothref={self._smoothref}")
-        if self._calibrated is not None:
-            logger.warning(f"Scan {self.scan} was previously calibrated. Calibrating again.")
         nspect = self._nint
         self._calibrated = np.ma.empty((nspect, self._nchan), dtype="d")
 
@@ -1910,8 +1906,6 @@ class NodScan(ScanBase):
         kwargs_opts.update(kwargs)
         if self._smoothref > 1 and kwargs_opts["verbose"]:
             logger.debug(f"NodScan smoothref={self._smoothref}")
-        if self._calibrated is not None:
-            logger.warning(f"Scan {self.scan} was previously calibrated. Calibrating again.")
         nspect = self._nint
         self._calibrated = np.ma.empty((nspect, self._nchan), dtype="d")
         self._calc_exposure()
@@ -2179,8 +2173,6 @@ class FSScan(ScanBase):
         # @todo upgrade fold from kwarg to arg
         logger.debug(f"FOLD={kwargs['fold']}")
         logger.debug(f"METHOD={kwargs['shift_method']}")
-        if self._calibrated is not None:
-            logger.warning(f"Scan {self.scan} was previously calibrated. Calibrating again.")
 
         # some helper functions, courtesy proto_getfs.py
         def channel_to_frequency(crval1, crpix1, cdelt1, vframe, nchan, nint, ndim=1):
@@ -2508,8 +2500,6 @@ class SubBeamNodScan(ScanBase):
 
     def calibrate(self, **kwargs):  ##SUBBEAMNOD
         """Calibrate the SubBeamNodScan data"""
-        if self._calibrated is not None:
-            logger.warning(f"Scan {self.scan} was previously calibrated. Calibrating again.")
         nspect = len(self._reftp)
         self._tsys = np.empty(nspect, dtype=float)
         self._exposure = np.empty(nspect, dtype=float)


### PR DESCRIPTION
A confusing message
```
   Scan XXX was previously calibrated. Calibrating again.
```
could show up, getting the user worried that perhaps the signal was modified again. This is not the case, 
so the warning message (5x in scan.py) was removed.