### PR TITLE
Issue 713

### DIFF
--- a/src/dysh/__init__.py
+++ b/src/dysh/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for dysh."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 all = ["version"]
 


### PR DESCRIPTION
This PR fixes issue #713 by computing the integration number per FITS file instead of globally. This way, even if the time stamps (DAT-OBS) are out of sync, the integration numbers do not skip values.