### PR TITLE
Issue #718

### DIFF
--- a/src/dysh/__init__.py
+++ b/src/dysh/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for dysh."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 all = ["version"]
 

--- a/src/dysh/fits/core.py
+++ b/src/dysh/fits/core.py
@@ -191,6 +191,7 @@ def summary_column_definitions():
         "SUBOBSMODE": str_col,
         "PROJID": str_col,
         "SUBREF_STATE": col_def("nunique", int, name="# SUBREF"),
+        "BINTABLE": col_def("mean", int),
     }
 
     return col_defs

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -603,6 +603,22 @@ class TestGBTFITSLoad:
         df = sdf.get_summary(columns=c)
         assert np.all(df.columns == c)
 
+        # With added columns.
+        add_columns = ["BINTABLE", "PROJID"]
+        expected_columns = list(sdf.get_summary().columns) + add_columns
+        df = sdf.get_summary(add_columns=add_columns)
+        assert np.all(df.columns == expected_columns)
+
+        # Repeated added columns.
+        add_columns = ["IFNUM", "SCAN"]
+        expected_columns = sdf.get_summary().columns
+        df = sdf.get_summary(add_columns=add_columns)
+        assert np.all(df.columns == expected_columns)
+
+        # Empty columns.
+        with pytest.raises(ValueError):
+            sdf.get_summary(columns=[])
+
         # Undefined column.
         columns += ["NOTTHERE"]
         with pytest.raises(ValueError):


### PR DESCRIPTION
Fix for issue #718.
* Summary now separates rows that have different BINTABLE values.
* Adds the `add_columns` argument to `summary` and `get_summary`, which allows the user to add columns to the default columns. Includes tests.