### PR TITLE
Fix issue #734

### DIFF
--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -463,6 +463,9 @@ class InteractiveSpanSelector:
     def on_press(self, event):
         if event.inaxes != self.ax:
             return
+        # Do nothing if another widget is enabled.
+        if self.canvas.toolbar.get_state()["_current_action"] != "":
+            return
         got_one = False
         for patch in self.regions:
             contains, attr = patch.contains(event)


### PR DESCRIPTION
Fix for issue #734 
It checks if another widget is enabled, and if so, does nothing with the selected regions.