### PR TITLE
Get hatch to work with uv and dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ path = "src/dysh/__init__.py"
 [tool.hatch.envs.default]
 # By default hatch will effectively do $ pip install dysh[all]
 features = ["all"]
+installer = "uv"
+pre-install-commands = [
+  "uv sync --active",
+]
 
 # run via: $ hatch run <script>
 [tool.hatch.envs.default.scripts]
@@ -96,6 +100,10 @@ docs = "sphinx-autobuild {root}/docs/source {root}/docs/build -b html {args}"
 docs-build = "sphinx-build {root}/docs/source {root}/docs/build -b html {args}"
 
 [tool.hatch.envs.test]
+installer = "uv"
+pre-install-commands = [
+  "uv sync --active",
+]
 
 # run via: $ hatch run test:<script>
 [tool.hatch.envs.test.scripts]


### PR DESCRIPTION
Not sure if this is a good idea or not, but I did figure out a way (I think) of using hatch with uv and specifically dependency groups (which don't seem to be respected by hatch since it uses `uv pip install ...`.

With this method I _think_ hatch should behave basically like uv does: `uv sync` is run before all commands (so lockfile is used)