### PR TITLE
Scan timeaverage mask

### DIFF
--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -963,7 +963,9 @@ class ScanBase(HistoricalBase, SpectralAverageMixin):
             w = np.ones_like(self.tsys_weight)
         else:
             raise ValueError("Unrecognized weights: must be 'tsys', None, or an array of numbers")
-        self._timeaveraged._data, sum_of_weights = np.ma.average(data, axis=0, weights=w, returned=True)
+        data_avg, sum_of_weights = np.ma.average(data, axis=0, weights=w, returned=True)
+        self._timeaveraged._data = data_avg
+        self._timeaveraged.mask = data_avg.mask
         self._timeaveraged._data.set_fill_value(np.nan)
         non_blanks = find_non_blanks(data)
         if w.shape == (len(self), self.nchan):

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -1550,11 +1550,13 @@ class Spectrum(Spectrum1D, HistoricalBase):
         meta["BANDWID"] = abs(meta["CDELT1"]) * len(new_flux)  # Hz
 
         # New Spectrum.
-        return self.make_spectrum(
+        new_spectrum = self.make_spectrum(
             Masked(new_flux, self.mask[start_idx:stop_idx]),
             meta=meta,
             observer_location=Observatory[meta["TELESCOP"]],
         )
+        new_spectrum._weights = self._weights[start_idx:stop_idx]
+        return new_spectrum
 
     @log_call_to_result
     def average(self, spectra, weights: str | np.ndarray | None = "tsys", align=False):

--- a/src/dysh/spectra/tests/test_scan.py
+++ b/src/dysh/spectra/tests/test_scan.py
@@ -511,6 +511,33 @@ class TestWeights:
         assert np.mean(x.weights) == pytest.approx(0.5 * sb.nint * scale, rel=1e-2)
 
 
+class TestScanBase:
+    def test_timeaverage_flags(self):
+        """
+        Test that `ScanBase.timeaverage()` produces the correct flags.
+        """
+        sdf_file = util.get_project_testdata() / "TGBT21A_501_11/TGBT21A_501_11_scan_152_ifnum_0_plnum_0.fits"
+        sdf = gbtfitsload.GBTFITSLoad(sdf_file, flag_vegas=False)
+        channel = [2000, 6000]
+        intnums = list(np.r_[0:70])
+        chanslc = slice(channel[0], channel[1])
+        sdf.flag(scan=152, channel=[channel], int=intnums)
+        tp_sb = sdf.gettp(scan=152, ifnum=0, plnum=0, fdnum=0)
+        # Mask is properly applied.
+        assert np.all(tp_sb[0]._calibrated[intnums, chanslc].mask)
+        tp = tp_sb[0].timeaverage()
+        assert not np.all(tp[chanslc].mask)
+        assert np.all(
+            tp.weights[chanslc] == pytest.approx(tp_sb[0].tsys_weight.sum() - tp_sb[0].tsys_weight[intnums].sum())
+        )
+        assert np.all(
+            tp[chanslc].weights == pytest.approx(tp_sb[0].tsys_weight.sum() - tp_sb[0].tsys_weight[intnums].sum())
+        )
+        assert np.all(tp.weights[: channel[0]] == pytest.approx(tp_sb[0].tsys_weight.sum()))
+        # Channel selection in dysh is inclusive of the upper edge.
+        assert np.all(tp.weights[channel[1] + 1 :] == pytest.approx(tp_sb[0].tsys_weight.sum()))
+
+
 class TestTPScan:
     def test_len_and_units(self, data_dir):
         """


### PR DESCRIPTION
Scan timeaverage updates mask (fixes issue #934).
It also updates Spectrum weights for slicing.