### PR TITLE
write repeated scan numbers

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -3062,7 +3062,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 df = select_from("FITSINDEX", k, _final)
                 bintables = df.BINTABLE.unique()
                 for b in bintables:  # loop over the bintables in this fitsfile
-                    rows = df.ROW.unique()
+                    rows = df.ROW[df.BINTABLE == b].unique()
                     rows.sort()
                     lr = len(rows)
                     if lr > 0:
@@ -3102,7 +3102,7 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
                 df = select_from("FITSINDEX", k, _final)
                 bintables = df.BINTABLE.unique()
                 for b in bintables:
-                    rows = df.ROW.unique()
+                    rows = df.ROW[df.BINTABLE == b].unique()
                     rows.sort()
                     lr = len(rows)
                     if lr > 0:


### PR DESCRIPTION
fix: GBTFITSLoad.write can handle repeated scans (issue #731)