### PR TITLE
Issue #985

### DIFF
--- a/src/dysh/spectra/scan.py
+++ b/src/dysh/spectra/scan.py
@@ -1482,11 +1482,11 @@ class ScanBlock(UserList, HistoricalBase, SpectralAverageMixin):
         for scan in self.data:  # [1:]:
             # check data shapes are the same
             thisshape = np.shape(scan._calibrated)
-            if thisshape != datashape:
+            if thisshape[1] != datashape[1]:
                 # @todo Variable length arrays? https://docs.astropy.org/en/stable/io/fits/usage/unfamiliar.html#variable-length-array-tables
                 # or write to separate bintables.
                 raise Exception(
-                    f"Data shapes of scans are not equal {thisshape}!={datashape}. Can't combine Scans into single"
+                    f"Number of channels in scans are not equal {thisshape[1]}!={datashape[1]}. Can't combine Scans into single"
                     " BinTableHDU"
                 )
             # check that the header keywords are the same

--- a/src/dysh/spectra/tests/test_scan.py
+++ b/src/dysh/spectra/tests/test_scan.py
@@ -1062,3 +1062,18 @@ class TestScanBlock:
         assert np.all(sb1[0]._get_all_meta("QD_XEL") == [1])
         sb0.append(sb1[0])
         sb0.write(tmp_path / "test.fits", overwrite=True)
+
+    def test_write_different_intnums(slef, data_dir, tmp_path):
+        """Test that we can write a ScanBlock with scans of different lengths."""
+        sdf_file = f"{data_dir}/AGBT05B_047_01/AGBT05B_047_01.raw.acs"
+        sdf = gbtfitsload.GBTFITSLoad(sdf_file)
+        sb1 = sdf.gettp(scan=51, ifnum=0, plnum=0, fdnum=0)
+        sb2 = sdf.gettp(scan=52, ifnum=0, plnum=0, fdnum=0, intnum=[0, 1, 2])
+        sb1.extend(sb2)
+        o = tmp_path / "test_write.fits"
+        sb1.write(o, overwrite=True)
+        sdf2 = gbtfitsload.GBTFITSLoad(o)
+        sb1_ = sdf2.gettp(scan=51, ifnum=0, plnum=0, fdnum=0)
+        assert np.all(sb1.data[0].calibrated == sb1_.data[0].calibrated)
+        sb2_ = sdf2.gettp(scan=52, ifnum=0, plnum=0, fdnum=0)
+        assert np.all(sb2.data[0].calibrated == sb2_.data[0].calibrated)


### PR DESCRIPTION
fix: ScanBlock can write scans with different intnums (issue #985)