### PR TITLE
add regions attribute to spectrum

### DIFF
--- a/docs/source/users_guide/iplotter.rst
+++ b/docs/source/users_guide/iplotter.rst
@@ -148,7 +148,7 @@ Use the ``remove=False`` option to just plot the baseline fit without removing i
 
 .. code-block::
 
-    ps.baseline(1, include=ps.get_selected_regions(), remove=False)
+    ps.baseline(1, include=ps.regions, remove=False)
 
 
 The fit looks good.
@@ -159,13 +159,13 @@ We can check the stats before and after to see they've improved.
 
 .. code-block::
 
-    ps.get_selected_regions()
+    print(ps.regions)
     [(210,2871)]
 
     print(f"{ps[210:2871].stats()['mean']:.4f}, {ps[210:2871].stats()['rms']:.4f}")
     -0.0780 K, 0.0204 K
 
-    ps.baseline(1,include=ps.get_selected_regions(),remove=True)
+    ps.baseline(1,include=ps.regions,remove=True)
 
     print(f"{ps[210:2871].stats()['mean']:.4f}, {ps[210:2871].stats()['rms']:.4f}")
     -0.0000 K, 0.0204 K

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -104,7 +104,7 @@ class SpectrumPlot(PlotBase):
     def _init_selector(self):
         if self._select:
             if not hasattr(self, "_selector") or self._selector is None:
-                self._selector = MultiSpanSelector(self.axes, minspan=1)
+                self._selector = MultiSpanSelector(self.axes, self._spectrum.get_selected_regions, minspan=1)
             elif hasattr(self, "_selector"):
                 self._selector.clear()
         # If select is False, and there is a selector, close it.
@@ -588,7 +588,7 @@ class SpectrumPlot(PlotBase):
 
 
 class MultiSpanSelector:
-    def __init__(self, ax, minspan=1):
+    def __init__(self, ax, on_selection=None, minspan=1):
         self.ax = ax
         self.canvas = ax.figure.canvas
         self.spans = []
@@ -603,6 +603,7 @@ class MultiSpanSelector:
 
         self.active_span = None
         self.selected_span = None
+        self.on_selection = on_selection
 
     def init_first_span(self):
         """
@@ -629,7 +630,14 @@ class MultiSpanSelector:
         return [span]
 
     def on_select(self, vmin, vmax):
+        """
+        Add a new span after a selection is made when needed,
+        and handle which span is active.
+        This is also where self.on_selection is called.
+        """
         span = vmax - vmin
+        # Here we need to check for all the existing spans,
+        # to make sure we do not create a new one if there's already an incomplete one.
         if span > self.minspan and np.all(np.diff(self.get_selected_regions(False)) > self.minspan):
             if self.active_span is not None:
                 self.active_span.set_active(False)
@@ -639,6 +647,8 @@ class MultiSpanSelector:
         elif self.active_span is not None:
             self.active_span.set_active(False)
             self.active_span = None
+        if self.on_selection is not None:
+            self.on_selection()
         return
 
     def on_press(self, event):

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -138,6 +138,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         self._exclude_regions = None
         self._include_regions = None  # do we really need this?
         self._plotter = None
+        self.regions = None
         # `self._resolution` is the spectral resolution in channels.
         # This will be 1 for VEGAS, and >1 for the ACS.
         if "FREQRES" in self.meta and "CDELT1" in self.meta:
@@ -318,7 +319,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         self._plotter.plot(**kwargs)
         return self._plotter
 
-    def get_selected_regions(self, unit=None):
+    def get_selected_regions(self, unit=None, ignore_incomplete=True):
         """Get selected regions from plot."""
         if self._plotter is None:
             raise TypeError("No plotter attached to spectrum. Use Spectrum.plot() first.")
@@ -338,6 +339,8 @@ class Spectrum(Spectrum1D, HistoricalBase):
             regions = exclude_to_spectral_region(regions, self)
             regions = spectral_region_to_unit(regions, self, unit=unit, append_doppler=True)
             regions = spectral_region_to_list_of_tuples(regions)
+
+        self.regions = regions
 
         return regions
 


### PR DESCRIPTION
Adds the "regions" attribute to Spectrum objects, and has it automatically update with the currently selected interactive regions whenever they change. This can be a persistent list of selected regions, even when the plotter has been closed.

This also maybe deprecates `spectrum.get_selected_regions()`.