### PR TITLE
tests: ignore Splatalogue HTTP errors

### DIFF
--- a/notebooks/examples/tests/test_notebooks.py
+++ b/notebooks/examples/tests/test_notebooks.py
@@ -8,6 +8,11 @@ from nbclient import NotebookClient
 # Collect notebook files at module level
 NOTEBOOK_DIR = Path("notebooks/examples/")
 NOTEBOOK_FILES = list(NOTEBOOK_DIR.glob("*.ipynb"))
+ALLOWED_ERROR_NAMES = [
+    "requests.exceptions.ReadTimeout",
+    "requests.exceptions.HTTPError",
+    "requests.exceptions.ConnectTimeout",
+]
 
 
 def check_notebook_execution(notebook_file):
@@ -26,7 +31,7 @@ def check_notebook_execution(notebook_file):
     try:
         # Change the current working directory to the notebook's directory
         os.chdir(notebook_dir)
-        client = NotebookClient(nb, timeout=600)
+        client = NotebookClient(nb, timeout=600, allow_error_names=ALLOWED_ERROR_NAMES)
         client.execute()
     finally:
         # Always restore directory

--- a/src/dysh/line/tests/test_search.py
+++ b/src/dysh/line/tests/test_search.py
@@ -1,6 +1,9 @@
+import warnings
+
 import astropy.units as u
 import numpy as np
 import pytest
+import requests
 from astroquery.splatalogue import Splatalogue
 
 from dysh.line import SpectralLineSearch
@@ -21,41 +24,55 @@ class TestSearch:
 
     def test_remote_query(self):
         Splatalogue.TIMEOUT = 90  # increase default from 60
-        z = SpectralLineSearch.query_lines(
-            min_frequency=115 * u.GHz,
-            max_frequency=116 * u.GHz,
-            chemical_name=" CO ",
-            only_NRAO_recommended=True,
-        )
-        assert len(z) == 1
+        try:
+            z = SpectralLineSearch.query_lines(
+                min_frequency=115 * u.GHz,
+                max_frequency=116 * u.GHz,
+                chemical_name=" CO ",
+                only_NRAO_recommended=True,
+            )
+            assert len(z) == 1
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            pytest.skip(f"HTTPError: {e}")
 
     def test_keywords(self):
-        z = SpectralLineSearch.query_lines(
-            min_frequency=1 * u.GHz,
-            max_frequency=10 * u.GHz,
-            cat="splat",  # also test minimum match for catalogs
-            chemical_name="Methyl Formate",
-            only_NRAO_recommended=True,
-            intensity_lower_limit=20,
-            intensity_type="sij",
-        )
-        assert len(z) == 22
-        assert min(z["sijmu2"]) >= 20
+        try:
+            z = SpectralLineSearch.query_lines(
+                min_frequency=1 * u.GHz,
+                max_frequency=10 * u.GHz,
+                cat="splat",  # also test minimum match for catalogs
+                chemical_name="Methyl Formate",
+                only_NRAO_recommended=True,
+                intensity_lower_limit=20,
+                intensity_type="sij",
+            )
+            assert len(z) == 22
+            assert min(z["sijmu2"]) >= 20
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            pytest.skip(f"HTTPError: {e}")
 
     def test_recomb(self):
-        z = SpectralLineSearch.recomb(line="Calpha", min_frequency=1 * u.GHz, max_frequency=10 * u.GHz)
-        assert len(z) == 100
+        try:
+            z = SpectralLineSearch.recomb(line="Calpha", min_frequency=1 * u.GHz, max_frequency=10 * u.GHz)
+            assert len(z) == 100
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            warnings.warn(e, stacklevel=2)
+            pass  # Do not skip here, because there's a test that does not require Splatalogue.
         # check that requesting only certain column names works
         columns = ["name", "rest_frequency"]
-        z = SpectralLineSearch.recomb(
-            min_frequency=2 * u.GHz,
-            max_frequency=8.4 * u.GHz,
-            line="Hbeta",
-            only_NRAO_recommended=False,
-            columns=columns,
-        )
-        assert len(z) == 71
-        assert z.colnames == columns
+        try:
+            z = SpectralLineSearch.recomb(
+                min_frequency=2 * u.GHz,
+                max_frequency=8.4 * u.GHz,
+                line="Hbeta",
+                only_NRAO_recommended=False,
+                columns=columns,
+            )
+            assert len(z) == 71
+            assert z.colnames == columns
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            warnings.warn(e, stacklevel=2)
+            pass  # Do not skip here, because there's a test that does not require Splatalogue.
 
         # all recombination lines from a local GBT specific catalog
         z = SpectralLineSearch.recomball(min_frequency=500 * u.MHz, max_frequency=1 * u.GHz, cat="gbtrecomb")
@@ -63,23 +80,38 @@ class TestSearch:
 
     def test_search_with_redshift(self):
         redshift = 0
-        z = SpectralLineSearch.recomb(
-            line="Halpha", min_frequency=1.022 * u.GHz, max_frequency=8.322 * u.GHz, redshift=redshift
-        )
-        diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
+        try:
+            z = SpectralLineSearch.recomb(
+                line="Halpha", min_frequency=1.022 * u.GHz, max_frequency=8.322 * u.GHz, redshift=redshift
+            )
+            diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
+            assert np.all(np.isclose(diff, 0.0, rtol=1e-8))
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            warnings.warn(e, stacklevel=2)
         redshift = 1.5
-        z = SpectralLineSearch.recomb(
-            line="Calpha", min_frequency=1 * u.GHz, max_frequency=10 * u.GHz, redshift=redshift
-        )
-        diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
-        assert np.all(np.isclose(diff, 0.0, rtol=1e-8))
+        try:
+            z = SpectralLineSearch.recomb(
+                line="Calpha", min_frequency=1 * u.GHz, max_frequency=10 * u.GHz, redshift=redshift
+            )
+            diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
+            assert np.all(np.isclose(diff, 0.0, rtol=1e-8))
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            warnings.warn(e, stacklevel=2)
         redshift = 5.0
-        z = SpectralLineSearch.query_lines(
-            cat="gbtlines", min_frequency=1 * u.GHz, max_frequency=10 * u.GHz, redshift=redshift
-        )
-        diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
-        assert np.all(np.isclose(diff, 0.0, rtol=1e-8))
+        try:
+            z = SpectralLineSearch.query_lines(
+                cat="gbtlines", min_frequency=1 * u.GHz, max_frequency=10 * u.GHz, redshift=redshift
+            )
+            diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
+            assert np.all(np.isclose(diff, 0.0, rtol=1e-8))
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            warnings.warn(e, stacklevel=2)
         redshift = 1
-        z = SpectralLineSearch.query_lines(
-            chemical_name="Carbon Monoxide", min_frequency=100 * u.GHz, max_frequency=120 * u.GHz, redshift=redshift
-        )
+        try:
+            z = SpectralLineSearch.query_lines(
+                chemical_name="Carbon Monoxide", min_frequency=100 * u.GHz, max_frequency=120 * u.GHz, redshift=redshift
+            )
+            diff = (z["obs_frequency"] * (1.0 + redshift) - z["rest_frequency"]).data
+            assert np.all(np.isclose(diff, 0.0, rtol=1e-8))
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as e:
+            pytest.skip(e)


### PR DESCRIPTION
Not so great about this: it does not tell you when a test was skipped because Splatalogue was down in certain cases.