### PR TITLE
add backend property. fix vegas flagging

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -1428,16 +1428,16 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             selection = self._selection
 
         if self.backend != "VEGAS" and self.backend != "unknown":
-            return #  Properly described non-VEGAS data will never enter the loop
-        
+            return  #  Properly described non-VEGAS data will never enter the loop
+
         try:
             df = selection.groupby(["FITSINDEX", "BINTABLE"])
             for _i, ((fi, bi), g) in enumerate(df):
                 backend = uniq(g["BACKEND"].to_numpy())
-                # If not VEGAS data , no data will be flagged.  
+                # If not VEGAS data , no data will be flagged.
                 # Don't log message because we dont want message for every file/bintable.
                 if len(backend) > 1 or str(backend[0]) != "VEGAS":
-                    return 
+                    return
                 vsprval = g["VSPRVAL"].to_numpy()
                 vspdelt = g["VSPDELT"].to_numpy()
                 vsprpix = g["VSPRPIX"].to_numpy()


### PR DESCRIPTION
This removes ``ignore_non_vegas`` as it should not be needed.  Adds a ``backend`` string property. Inside the flagging loop it doublechecks BACKEND for the affected rows and refuses to flag if not "VEGAS".

Note I have some commented out code at the top of ``flag_vegas_spurs`` that would never flag data clearly marked as non-VEGAS.  You can uncomment that if you think that is appropriate behavior. 

ubuntu tests in my sandbox pass. fingers crossed for macosx here.