### PR TITLE
1017 baseline issue using include regions

### DIFF
--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -194,7 +194,7 @@ def sort_spectral_region_subregions(spectral_region):
 
 def invert_spectral_region(sr, refspec):
     """
-    Invert an spectral region. The spectral region is sorted and the ranges has been merged previously.
+    Invert an spectral region. The spectral region, `sr`, must have been sorted and its ranges merged.
 
     Parameters
     ----------
@@ -208,8 +208,10 @@ def invert_spectral_region(sr, refspec):
     `~specutils.SpectralRegion`
         Inverted spectral region.
     """
-    bl = refspec.spectral_axis.to(sr.bounds[0].unit, equivalencies=refspec.equivalencies).quantity.min()
-    bu = refspec.spectral_axis.to(sr.bounds[0].unit, equivalencies=refspec.equivalencies).quantity.max()
+    u_tgt = sr.bounds[0].unit
+    sa_in_tgt_u = refspec.spectral_axis.to(u_tgt, equivalencies=refspec.equivalencies).quantity
+    bl = sa_in_tgt_u.min()
+    bu = sa_in_tgt_u.max()
     sr._reorder()
     ll = [bl, *list(sum(sr._subregions, ())), bu]
     return exclude_to_spectral_region(list(grouper(ll, 2)), refspec)
@@ -323,6 +325,14 @@ def exclude_to_spectral_region(exclude, refspec):
             if len(exclude) == 0:
                 raise ValueError(f"Region selection is empty (nchan={len(sa)}).") from exc
             sr = SpectralRegion(sa.quantity[exclude])
+
+    # Take care of units.
+    # Spectral region does not support mixed units in SpectralRegion,
+    # and astropy does not return the correct value if, e.g., one converts
+    # 1 Hz to GHz -- the last digit gets rounded which means one channel can be
+    # included/excluded when it shouldn't. See issue #1017.
+    tgt_u = sa.unit
+    sr = spectral_region_to_unit(sr, refspec, unit=tgt_u, append_doppler=True)
 
     return sr
 
@@ -495,7 +505,6 @@ def exclude_to_region_list(exclude, spectrum, clip_exclude=True):
     """
 
     spectral_region = exclude_to_spectral_region(exclude, spectrum)
-    spectral_region = spectral_region_to_unit(spectral_region, spectrum)
     sort_spectral_region_subregions(spectral_region)
     if clip_exclude:
         clip_spectral_region_subregions(spectral_region, spectrum)

--- a/src/dysh/spectra/tests/test_spectra_core.py
+++ b/src/dysh/spectra/tests/test_spectra_core.py
@@ -209,17 +209,29 @@ class TestBaseline:
         """
 
         s = Spectrum.fake_spectrum(nchan=512)
-        # Regions in channels outside the channel range get clipped,
-        # so the second regions would be equal to `[nchan,nchan]`
+        # Regions with channels outside the spectrum get clipped,
+        # so the second region would be equal to `[nchan,nchan]`
         # after clipping.
         r = [[100, 200], [1000, 2000]]
         sr = core.exclude_to_spectral_region(r, s)
         assert sr[0].bounds[0] == s.spectral_axis.quantity[r[0][0]]
         assert sr[0].bounds[1] == s.spectral_axis.quantity[r[0][1]]
 
-        # An empty regions should raise a ValueError.
+        # An empty region should raise a ValueError.
         with pytest.raises(ValueError):
             core.exclude_to_spectral_region(r[1], s)
+
+    def test_include_to_exclude_spectral_region(self):
+        """Test the inversion of an inclusion region to an exclusion one."""
+        # Spectral axis will be in Hz by default.
+        s = Spectrum.fake_spectrum(nchan=512)
+        # Use GHz here, to replicate the error due to loss of precision.
+        # See issue #1017.
+        r = [[s.spectral_axis.min().to("GHz") * 0.9, s.spectral_axis.mean().to("GHz")]]
+        r_inv = core.include_to_exclude_spectral_region(r, s)
+        # `SpectralRegion.bounds` gives `[min,max]`.
+        assert r_inv.bounds[0].to("Hz").value == s.spectral_axis.min().value
+        assert r_inv.bounds[1].to("Hz").value == s.spectral_axis.max().value
 
 
 def test_mask_fshift():


### PR DESCRIPTION
Fixes issue #1017 
Forces the use of the same units as the ``Spectrum.spectral_axis`` in the internal handling of the include region.
Otherwise you get silly results like:
```Python
s.spectral_axis[0].to("GHz").to("Hz").value == s.spectral_axis[0].value
```
being ``False``.