### PR TITLE
474 spectrum header

### DIFF
--- a/src/dysh/plot/core.py
+++ b/src/dysh/plot/core.py
@@ -38,4 +38,3 @@ def parse_html(s):
     s = s.replace(" (TopModel)", "")
 
     return s
-

--- a/src/dysh/plot/core.py
+++ b/src/dysh/plot/core.py
@@ -2,7 +2,14 @@
 Core plotting functions.
 """
 
+from astropy.coordinates import SkyCoord
+
 from dysh.log import logger
+
+from ..coordinates import (
+    Observatory,
+    crval4_to_pol,
+)
 
 
 def check_kwargs(known_kwargs, kwargs):
@@ -38,3 +45,4 @@ def parse_html(s):
     s = s.replace(" (TopModel)", "")
 
     return s
+

--- a/src/dysh/plot/core.py
+++ b/src/dysh/plot/core.py
@@ -2,14 +2,7 @@
 Core plotting functions.
 """
 
-from astropy.coordinates import SkyCoord
-
 from dysh.log import logger
-
-from ..coordinates import (
-    Observatory,
-    crval4_to_pol,
-)
 
 
 def check_kwargs(known_kwargs, kwargs):

--- a/src/dysh/plot/plotbase.py
+++ b/src/dysh/plot/plotbase.py
@@ -9,16 +9,14 @@ import sys
 import astropy.units as u
 import matplotlib as mpl
 import numpy as np
-from astropy.coordinates import SkyCoord
 
 from dysh.log import logger
 
 from ..coordinates import (
-    Observatory,
     crval4_to_pol,
     ra2ha,
 )
-from ..util.core import abbreviate_to, in_notebook
+from ..util.core import abbreviate_to, coord_formatter, in_notebook, time_formatter
 
 # Only import the appropriate GUI to avoid errors.
 on_rtd = os.environ.get("READTHEDOCS") == "True"
@@ -132,26 +130,6 @@ class PlotBase:
 
         hcoords = np.array([0.05, 0.21, 0.41, 0.59, 0.77])
         vcoords = np.array([0.94, 0.9, 0.86])
-
-        def time_formatter(time_sec):
-            hh = int(time_sec // 3600)
-            mm = int((time_sec - 3600 * hh) // 60)
-            ss = np.around((time_sec - 3600 * hh - 60 * mm), 1)
-            return f"{str(hh).zfill(2)} {str(mm).zfill(2)} {str(ss).zfill(3)}"
-
-        def coord_formatter(s):
-            sc = SkyCoord(
-                s.meta["CRVAL2"],
-                s.meta["CRVAL3"],
-                unit="deg",
-                frame=s.meta["RADESYS"].lower(),
-                obstime=s._obstime,
-                location=Observatory.get_earth_location(s.meta["SITELONG"], s.meta["SITELAT"], s.meta["SITEELEV"]),
-            )
-            out_str = sc.transform_to("fk5").to_string("hmsdms", sep=" ", precision=2)[:-1]
-            out_ra = out_str[:11]
-            out_dec = out_str[12:]
-            return out_ra, out_dec
 
         # col 1
         self.axis.annotate(f"Scan(s) {self.fmt_scans():>10}", (hcoords[0], vcoords[0]), xycoords=xyc, size=fsize_small)

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -207,7 +207,6 @@ class Spectrum(Spectrum1D, HistoricalBase):
         out += f"Proc : {m.get('PROC'):>6}       UT    :  {utc}         Tcal :   {tcal} K\n"
 
         lst = time_formatter(m.get("LST"))
-        #ha = f"{((m.get('LST') / 3600.0) - m.get('CRVAL2') / 360.0 * 24):10.2f}"
         ha = ra2ha(m.get("LST"), m.get("CRVAL2"))
         tsys = f"{m.get('TSYS'):10.2f}"
         out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst}      {ha}        Tsys :   {tsys} K\n"

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -173,12 +173,12 @@ class Spectrum(Spectrum1D, HistoricalBase):
         """
         m = self.meta
 
-        proj = m.get('PROJID', 'N/A')
-        src  = m.get('OBJECT', 'N/A')
-        obs  = m.get('OBSERVER', 'N/A')
+        proj = m.get("PROJID", "N/A")
+        src = m.get("OBJECT", "N/A")
+        obs = m.get("OBSERVER", "N/A")
 
         def utc_formatter(ut):
-            dt = ut.split('_')
+            dt = ut.split("_")
             out = f"{dt[3]}  {dt[0]}-{dt[1]}-{dt[2]}"
             return out
 
@@ -187,31 +187,31 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         RA, DEC = coord_formatter(self)
 
-        fsky = f"{m.get('OBSFREQ')/1e9:10.6f}"
+        fsky = f"{m.get('OBSFREQ') / 1e9:10.6f}"
         out += f"Scan : {m.get('SCAN'):>6}       RADec :  {RA} {DEC}      Fsky : {fsky} GHz\n"
 
-        frst = f"{m.get('RESTFRQ')/1e9:10.6f}"
+        frst = f"{m.get('RESTFRQ') / 1e9:10.6f}"
         out += f"Int  :    N/A       Eqnx  :  {m.get('EQUINOX')}                       Frst : {frst} GHz\n"
 
-        velo = f"{m.get('VELOCITY')/1e3:<8.1f}"
-        bw = f"{m.get('BANDWID')/1e6:10.3f}"
+        velo = f"{m.get('VELOCITY') / 1e3:<8.1f}"
+        bw = f"{m.get('BANDWID') / 1e6:10.3f}"
         out += f"Pol  :     {crval4_to_pol[m.get('CRVAL4')]}       V     :  {velo}   {m.get('VELDEF')}          BW   : {bw} MHz\n"
 
         az = f"{m.get('AZIMUTH'):7.3f}"
         el = f"{m.get('ELEVATIO'):7.3f}"
-        delf = f"{m.get('CDELT1')/1e3:10.3f}"
+        delf = f"{m.get('CDELT1') / 1e3:10.3f}"
         out += f"IF   : {m.get('IFNUM'):>6}       AzEl  :  {az} {el}              delF : {delf} kHz\n"
 
-        glon,glat = coord_formatter(self,'galactic',fmt='decimal')
+        glon, glat = coord_formatter(self, "galactic", fmt="decimal")
         exp = f"{m.get('EXPOSURE'):10.1f}"
         out += f"Feed : {m.get('FDNUM'):>6}       Gal   :  {glon} {glat}               Exp  :   {exp} s\n"
 
         tcal = f"{m.get('TCAL'):10.2f}"
-        utc = utc_formatter(m.get('TIMESTAMP'))
+        utc = utc_formatter(m.get("TIMESTAMP"))
         out += f"Proc : {m.get('PROC'):>6}       UT    :  {utc}         Tcal :   {tcal} K\n"
 
-        lst = time_formatter(m.get('LST'))
-        ha = f"{((m.get('LST')/3600.) - m.get('CRVAL2')/360.*24):10.2f}"
+        lst = time_formatter(m.get("LST"))
+        ha = f"{((m.get('LST') / 3600.0) - m.get('CRVAL2') / 360.0 * 24):10.2f}"
         tsys = f"{m.get('TSYS'):10.2f}"
         out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst} {ha}        Tsys :   {tsys} K\n"
 

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -193,21 +193,21 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         c1_pad = 20
         c1_subpad = 10
-        c2_pad = 38
-        c3_pad = 10
+        c2_pad = 37
+        c3_pad = 9
 
         #row 2
         fsky = f"{m.get('OBSFREQ') / 1e9:10.6f}"
         col1 = f"Scan : {m.get('SCAN'):>{c1_subpad}}"
         col2 = f"RADec :  {RA} {DEC}"
-        col3 = f"Fsky : {fsky:>{c3_pad}} GHz"
+        col3 = f"Fsky  : {fsky:>{c3_pad}} GHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         #row 3
         frest = f"{m.get('RESTFRQ') / 1e9:10.6f}"
         col1 = "Int  :        N/A   "
         col2 = f"Eqnx  :  {m.get('EQUINOX')}"
-        col3 = f"Frst : {frest:>{c3_pad}} GHz"
+        col3 = f"Frest : {frest:>{c3_pad}} GHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         #row 4
@@ -215,7 +215,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         bw = f"{m.get('BANDWID') / 1e6:10.3f}"
         col1 = f"Pol  : {crval4_to_pol[m.get('CRVAL4')]:>{c1_subpad}}"
         col2 = f"V     :  {velo}{m.get('VELDEF'):>8}"
-        col3 = F"BW   : {bw:>{c3_pad}} MHz"
+        col3 = F"BW    : {bw:>{c3_pad}} MHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         #row 5
@@ -224,7 +224,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         delf = f"{np.abs(m.get('CDELT1')) / 1e3:10.3f}"
         col1 = f"IF   : {m.get('IFNUM'):>{c1_subpad}}"
         col2 = f"AzEl  : {az}  {el}"
-        col3 = f"delF : {delf:>{c3_pad}} kHz"
+        col3 = f"delF  : {delf:>{c3_pad}} kHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         #row 6
@@ -234,7 +234,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         exp = f"{m.get('EXPOSURE'):10.1f}"
         col1 = f"Feed : {m.get('FDNUM'):>{c1_subpad}}"
         col2 = f"Gal   : {glon}  {glat}"
-        col3 = f"Exp  : {exp:>{c3_pad}}   s"
+        col3 = f"Exp   : {exp:>{c3_pad}}   s"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         #row 7
@@ -242,7 +242,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         utc = utc_formatter(m.get("TIMESTAMP"))
         col1 = f"Proc : {m.get('PROC')[:9]:>{c1_subpad}}"
         col2 = f"UT    :  {utc}"
-        col3 = f"Tcal : {tcal:>{c3_pad}}   K"
+        col3 = f"Tcal  : {tcal:>{c3_pad}}   K"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         #row 8
@@ -251,7 +251,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         tsys = f"{m.get('TSYS'):10.2f}"
         col1 = f"Seqn : {m.get('PROCSEQN'):>{c1_subpad}}"
         col2 = f"LST/HA:  {lst}      {ha}"
-        col3 = f"Tsys : {tsys:>{c3_pad}}   K"
+        col3 = f"Tsys  : {tsys:>{c3_pad}}   K"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         out += "-" * 80

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -180,14 +180,13 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         proj = m.get("PROJID", "N/A")
         obs = m.get("OBSERVER", "N/A")
-        src_pad = 45 - len(obs) # amt of chars of src we can afford to print
+        src_pad = 45 - len(obs)  # amt of chars of src we can afford to print
         src = m.get("OBJECT", "N/A")[:src_pad]
-
 
         col1 = f"Proj: {proj:<16}"
         col2 = f"Src : {src:<{src_pad}}"
         col3 = f"Obs : {obs}"
-        out += f"{col1:<22}{col2}{col3:>{len(obs)+5}}\n\n"
+        out += f"{col1:<22}{col2}{col3:>{len(obs) + 5}}\n\n"
 
         RA, DEC = coord_formatter(self)
 
@@ -196,29 +195,29 @@ class Spectrum(Spectrum1D, HistoricalBase):
         c2_pad = 37
         c3_pad = 9
 
-        #row 2
+        # row 2
         fsky = f"{m.get('OBSFREQ') / 1e9:10.6f}"
         col1 = f"Scan : {m.get('SCAN'):>{c1_subpad}}"
         col2 = f"RADec :  {RA} {DEC}"
         col3 = f"Fsky  : {fsky:>{c3_pad}} GHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        #row 3
+        # row 3
         frest = f"{m.get('RESTFRQ') / 1e9:10.6f}"
         col1 = "Int  :        N/A   "
         col2 = f"Eqnx  :  {m.get('EQUINOX')}"
         col3 = f"Frest : {frest:>{c3_pad}} GHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        #row 4
+        # row 4
         velo = f"{m.get('VELOCITY') / 1e3:<8.1f}"
         bw = f"{m.get('BANDWID') / 1e6:10.3f}"
         col1 = f"Pol  : {crval4_to_pol[m.get('CRVAL4')]:>{c1_subpad}}"
         col2 = f"V     :  {velo}{m.get('VELDEF'):>8}"
-        col3 = F"BW    : {bw:>{c3_pad}} MHz"
+        col3 = f"BW    : {bw:>{c3_pad}} MHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        #row 5
+        # row 5
         az = f"{m.get('AZIMUTH'):7.3f}"
         el = f"{m.get('ELEVATIO'):7.3f}"
         delf = f"{np.abs(m.get('CDELT1')) / 1e3:10.3f}"
@@ -227,7 +226,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         col3 = f"delF  : {delf:>{c3_pad}} kHz"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        #row 6
+        # row 6
         glon, glat = coord_formatter(self, "galactic", fmt="decimal")
         print(glon)
         print(glat)
@@ -237,7 +236,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         col3 = f"Exp   : {exp:>{c3_pad}}   s"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        #row 7
+        # row 7
         tcal = f"{m.get('TCAL'):10.2f}"
         utc = utc_formatter(m.get("TIMESTAMP"))
         col1 = f"Proc : {m.get('PROC')[:9]:>{c1_subpad}}"
@@ -245,7 +244,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         col3 = f"Tcal  : {tcal:>{c3_pad}}   K"
         out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        #row 8
+        # row 8
         lst = time_formatter(m.get("LST"))
         ha = ra2ha(m.get("LST"), m.get("CRVAL2"))
         tsys = f"{m.get('TSYS'):10.2f}"

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -39,6 +39,7 @@ from ..coordinates import (  # is_topocentric,; topocentric_velocity_to_frame,
     frame_to_label,
     get_velocity_in_frame,
     make_target,
+    ra2ha,
     replace_convention,
     sanitize_skycoord,
     veldef_to_convention,
@@ -51,7 +52,7 @@ from ..util import (
     docstring_parameter,
     minimum_string_match,
 )
-from ..util.core import coord_formatter, time_formatter
+from ..util.core import coord_formatter, time_formatter, utc_formatter
 from ..util.docstring_manip import copy_docstring
 from . import (
     FWHM_TO_STDDEV,
@@ -169,18 +170,13 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
     def header(self):
         """
-        Prints useful information about the spectrum.
+        Prints header information about the spectrum, including sky coordinates, frequency information, and states.
         """
         m = self.meta
 
         proj = m.get("PROJID", "N/A")
         src = m.get("OBJECT", "N/A")
         obs = m.get("OBSERVER", "N/A")
-
-        def utc_formatter(ut):
-            dt = ut.split("_")
-            out = f"{dt[3]}  {dt[0]}-{dt[1]}-{dt[2]}"
-            return out
 
         out = "-" * 80 + "\n"
         out += f"Proj: {proj:<15} Src : {src:<25}     Obs : {obs:<15}\n\n"
@@ -211,9 +207,10 @@ class Spectrum(Spectrum1D, HistoricalBase):
         out += f"Proc : {m.get('PROC'):>6}       UT    :  {utc}         Tcal :   {tcal} K\n"
 
         lst = time_formatter(m.get("LST"))
-        ha = f"{((m.get('LST') / 3600.0) - m.get('CRVAL2') / 360.0 * 24):10.2f}"
+        #ha = f"{((m.get('LST') / 3600.0) - m.get('CRVAL2') / 360.0 * 24):10.2f}"
+        ha = ra2ha(m.get("LST"), m.get("CRVAL2"))
         tsys = f"{m.get('TSYS'):10.2f}"
-        out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst} {ha}        Tsys :   {tsys} K\n"
+        out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst}      {ha}        Tsys :   {tsys} K\n"
 
         out += "-" * 80
         print(out)

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -168,6 +168,9 @@ class Spectrum(Spectrum1D, HistoricalBase):
         return self.meta.get(prop, None)
 
     def header(self):
+        """
+        Prints useful information about the spectrum.
+        """
         m = self.meta
 
         proj = m.get('PROJID', 'N/A')
@@ -181,7 +184,6 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         out = "-" * 80 + "\n"
         out += f"Proj: {proj:<15} Src : {src:<25}     Obs : {obs:<15}\n\n"
-
 
         RA, DEC = coord_formatter(self)
 
@@ -214,9 +216,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst} {ha}        Tsys :   {tsys} K\n"
 
         out += "-" * 80
-
         print(out)
-
 
     @property
     def nchan(self) -> int:

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -171,45 +171,88 @@ class Spectrum(Spectrum1D, HistoricalBase):
     def header(self):
         """
         Prints header information about the spectrum, including sky coordinates, frequency information, and states.
+        RA/Dec coordinates are given in HH:MM:SS, DD:MM:SS; V is given in km/s;
+        Az/El and Galactic coordinates are in decimal degrees; UT is given in YYYY_MM_DD HH:MM:SS;
+        LST is in HH:MM:SS, and HA is in decimal hours.
         """
         m = self.meta
+        out = "-" * 80 + "\n"
 
         proj = m.get("PROJID", "N/A")
-        src = m.get("OBJECT", "N/A")
         obs = m.get("OBSERVER", "N/A")
+        src_pad = 45 - len(obs) # amt of chars of src we can afford to print
+        src = m.get("OBJECT", "N/A")[:src_pad]
 
-        out = "-" * 80 + "\n"
-        out += f"Proj: {proj:<15} Src : {src:<25}     Obs : {obs:<15}\n\n"
+
+        col1 = f"Proj: {proj:<16}"
+        col2 = f"Src : {src:<{src_pad}}"
+        col3 = f"Obs : {obs}"
+        out += f"{col1:<22}{col2}{col3:>{len(obs)+5}}\n\n"
 
         RA, DEC = coord_formatter(self)
 
+        c1_pad = 20
+        c1_subpad = 10
+        c2_pad = 38
+        c3_pad = 10
+
+        #row 2
         fsky = f"{m.get('OBSFREQ') / 1e9:10.6f}"
-        out += f"Scan : {m.get('SCAN'):>6}       RADec :  {RA} {DEC}      Fsky : {fsky} GHz\n"
+        col1 = f"Scan : {m.get('SCAN'):>{c1_subpad}}"
+        col2 = f"RADec :  {RA} {DEC}"
+        col3 = f"Fsky : {fsky:>{c3_pad}} GHz"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
-        frst = f"{m.get('RESTFRQ') / 1e9:10.6f}"
-        out += f"Int  :    N/A       Eqnx  :  {m.get('EQUINOX')}                       Frst : {frst} GHz\n"
+        #row 3
+        frest = f"{m.get('RESTFRQ') / 1e9:10.6f}"
+        col1 = "Int  :        N/A   "
+        col2 = f"Eqnx  :  {m.get('EQUINOX')}"
+        col3 = f"Frst : {frest:>{c3_pad}} GHz"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
+        #row 4
         velo = f"{m.get('VELOCITY') / 1e3:<8.1f}"
         bw = f"{m.get('BANDWID') / 1e6:10.3f}"
-        out += f"Pol  :     {crval4_to_pol[m.get('CRVAL4')]}       V     :  {velo}   {m.get('VELDEF')}          BW   : {bw} MHz\n"
+        col1 = f"Pol  : {crval4_to_pol[m.get('CRVAL4')]:>{c1_subpad}}"
+        col2 = f"V     :  {velo}{m.get('VELDEF'):>8}"
+        col3 = F"BW   : {bw:>{c3_pad}} MHz"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
+        #row 5
         az = f"{m.get('AZIMUTH'):7.3f}"
         el = f"{m.get('ELEVATIO'):7.3f}"
-        delf = f"{m.get('CDELT1') / 1e3:10.3f}"
-        out += f"IF   : {m.get('IFNUM'):>6}       AzEl  :  {az} {el}              delF : {delf} kHz\n"
+        delf = f"{np.abs(m.get('CDELT1')) / 1e3:10.3f}"
+        col1 = f"IF   : {m.get('IFNUM'):>{c1_subpad}}"
+        col2 = f"AzEl  : {az}  {el}"
+        col3 = f"delF : {delf:>{c3_pad}} kHz"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
+        #row 6
         glon, glat = coord_formatter(self, "galactic", fmt="decimal")
+        print(glon)
+        print(glat)
         exp = f"{m.get('EXPOSURE'):10.1f}"
-        out += f"Feed : {m.get('FDNUM'):>6}       Gal   :  {glon} {glat}               Exp  :   {exp} s\n"
+        col1 = f"Feed : {m.get('FDNUM'):>{c1_subpad}}"
+        col2 = f"Gal   : {glon}  {glat}"
+        col3 = f"Exp  : {exp:>{c3_pad}}   s"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
+        #row 7
         tcal = f"{m.get('TCAL'):10.2f}"
         utc = utc_formatter(m.get("TIMESTAMP"))
-        out += f"Proc : {m.get('PROC'):>6}       UT    :  {utc}         Tcal :   {tcal} K\n"
+        col1 = f"Proc : {m.get('PROC')[:9]:>{c1_subpad}}"
+        col2 = f"UT    :  {utc}"
+        col3 = f"Tcal : {tcal:>{c3_pad}}   K"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
+        #row 8
         lst = time_formatter(m.get("LST"))
         ha = ra2ha(m.get("LST"), m.get("CRVAL2"))
         tsys = f"{m.get('TSYS'):10.2f}"
-        out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst}      {ha}        Tsys :   {tsys} K\n"
+        col1 = f"Seqn : {m.get('PROCSEQN'):>{c1_subpad}}"
+        col2 = f"LST/HA:  {lst}      {ha}"
+        col3 = f"Tsys : {tsys:>{c3_pad}}   K"
+        out += f"{col1:<{c1_pad}}{col2:<{c2_pad}}{col3}\n"
 
         out += "-" * 80
         print(out)

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -35,6 +35,7 @@ from ..coordinates import (  # is_topocentric,; topocentric_velocity_to_frame,
     astropy_convenience_frame_names,
     astropy_frame_dict,
     change_veldef,
+    crval4_to_pol,
     frame_to_label,
     get_velocity_in_frame,
     make_target,
@@ -50,6 +51,7 @@ from ..util import (
     docstring_parameter,
     minimum_string_match,
 )
+from ..util.core import coord_formatter, time_formatter
 from ..util.docstring_manip import copy_docstring
 from . import (
     FWHM_TO_STDDEV,
@@ -164,6 +166,57 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         """
         return self.meta.get(prop, None)
+
+    def header(self):
+        m = self.meta
+
+        proj = m.get('PROJID', 'N/A')
+        src  = m.get('OBJECT', 'N/A')
+        obs  = m.get('OBSERVER', 'N/A')
+
+        def utc_formatter(ut):
+            dt = ut.split('_')
+            out = f"{dt[3]}  {dt[0]}-{dt[1]}-{dt[2]}"
+            return out
+
+        out = "-" * 80 + "\n"
+        out += f"Proj: {proj:<15} Src : {src:<25}     Obs : {obs:<15}\n\n"
+
+
+        RA, DEC = coord_formatter(self)
+
+        fsky = f"{m.get('OBSFREQ')/1e9:10.6f}"
+        out += f"Scan : {m.get('SCAN'):>6}       RADec :  {RA} {DEC}      Fsky : {fsky} GHz\n"
+
+        frst = f"{m.get('RESTFRQ')/1e9:10.6f}"
+        out += f"Int  :    N/A       Eqnx  :  {m.get('EQUINOX')}                       Frst : {frst} GHz\n"
+
+        velo = f"{m.get('VELOCITY')/1e3:<8.1f}"
+        bw = f"{m.get('BANDWID')/1e6:10.3f}"
+        out += f"Pol  :     {crval4_to_pol[m.get('CRVAL4')]}       V     :  {velo}   {m.get('VELDEF')}          BW   : {bw} MHz\n"
+
+        az = f"{m.get('AZIMUTH'):7.3f}"
+        el = f"{m.get('ELEVATIO'):7.3f}"
+        delf = f"{m.get('CDELT1')/1e3:10.3f}"
+        out += f"IF   : {m.get('IFNUM'):>6}       AzEl  :  {az} {el}              delF : {delf} kHz\n"
+
+        glon,glat = coord_formatter(self,'galactic',fmt='decimal')
+        exp = f"{m.get('EXPOSURE'):10.1f}"
+        out += f"Feed : {m.get('FDNUM'):>6}       Gal   :  {glon} {glat}               Exp  :   {exp} s\n"
+
+        tcal = f"{m.get('TCAL'):10.2f}"
+        utc = utc_formatter(m.get('TIMESTAMP'))
+        out += f"Proc : {m.get('PROC'):>6}       UT    :  {utc}         Tcal :   {tcal} K\n"
+
+        lst = time_formatter(m.get('LST'))
+        ha = f"{((m.get('LST')/3600.) - m.get('CRVAL2')/360.*24):10.2f}"
+        tsys = f"{m.get('TSYS'):10.2f}"
+        out += f"Seqn : {m.get('PROCSEQN'):>6}       LST/HA:  {lst} {ha}        Tsys :   {tsys} K\n"
+
+        out += "-" * 80
+
+        print(out)
+
 
     @property
     def nchan(self) -> int:

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -228,8 +228,6 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
         # row 6
         glon, glat = coord_formatter(self, "galactic", fmt="decimal")
-        print(glon)
-        print(glat)
         exp = f"{m.get('EXPOSURE'):10.1f}"
         col1 = f"Feed : {m.get('FDNUM'):>{c1_subpad}}"
         col2 = f"Gal   : {glon}  {glat}"

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1293,3 +1293,7 @@ class TestSpectrum:
             s.append(q)
         x = average_spectra(s, weights="spectral")
         assert np.all(x.weights == np.sum(np.arange(nspec + 1)))
+
+    def test_header(self):
+        s = Spectrum.fake_spectrum()
+        s.header()

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1294,6 +1294,9 @@ class TestSpectrum:
         x = average_spectra(s, weights="spectral")
         assert np.all(x.weights == np.sum(np.arange(nspec + 1)))
 
-    def test_header(self):
+    def test_header(self, capsys):
+        expected = """--------------------------------------------------------------------------------\nProj: TGBT21A_501_11  Src : NGC2415                          Obs : A. Dysh User\n\nScan :        152   RADec :  07 36 57.31 +35 14 35.3     Fsky  :   1.402545 GHz\nInt  :        N/A   Eqnx  :  2000.0                      Frest :   1.420406 GHz\nPol  :         YY   V     :  3784.0  OPTI-HEL            BW    :     23.438 MHz\nIF   :          0   AzEl  : 285.951   42.101             delF  :      0.715 kHz\nFeed :          0   Gal   : 184.136  23.987              Exp   :       44.9   s\nProc :      OnOff   UT    :  07:38:37  2021-02-10        Tcal  :       1.46   K\nSeqn :          1   LST/HA:  11 41 41.9      4.08        Tsys  :      17.93   K\n--------------------------------------------------------------------------------\n"""
         s = Spectrum.fake_spectrum()
         s.header()
+        captured = capsys.readouterr()
+        assert captured.out == expected

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -794,11 +794,12 @@ def coord_formatter(s, frame="fk5", fmt="hmsdms"):
         location=Observatory[s.meta["TELESCOP"]],
     )
     if fmt == "decimal":
-        out_str = sc.transform_to(frame).to_string(fmt, precision=3)
+        out_str = sc.transform_to(frame).to_string(fmt, precision=3).split(" ")
+        out_ra, out_dec = out_str[0], out_str[1]
     else:
         out_str = sc.transform_to(frame).to_string(fmt, sep=" ", precision=2)[:-1]
-    out_ra = out_str[:11]
-    out_dec = out_str[12:]
+        out_ra = out_str[:11]
+        out_dec = out_str[12:]
     return out_ra, out_dec
 
 

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -783,7 +783,8 @@ def inner_channel_slice(nchan: int, fedge: float = 0.1) -> slice:
     stop = -(start - 1)
     return slice(start, stop, 1)
 
-def coord_formatter(s,frame='fk5',fmt='hmsdms'):
+
+def coord_formatter(s, frame="fk5", fmt="hmsdms"):
     sc = SkyCoord(
         s.meta["CRVAL2"],
         s.meta["CRVAL3"],
@@ -792,13 +793,14 @@ def coord_formatter(s,frame='fk5',fmt='hmsdms'):
         obstime=s._obstime,
         location=Observatory.get_earth_location(s.meta["SITELONG"], s.meta["SITELAT"], s.meta["SITEELEV"]),
     )
-    if fmt=='decimal':
+    if fmt == "decimal":
         out_str = sc.transform_to(frame).to_string(fmt, precision=3)
     else:
         out_str = sc.transform_to(frame).to_string(fmt, sep=" ", precision=2)[:-1]
     out_ra = out_str[:11]
     out_dec = out_str[12:]
     return out_ra, out_dec
+
 
 def time_formatter(time_sec):
     hh = int(time_sec // 3600)

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -18,10 +18,7 @@ from astropy.time import Time
 from astropy.units.quantity import Quantity
 from IPython.display import HTML, display
 
-from ..coordinates import (
-    Observatory,
-    crval4_to_pol,
-)
+from ..coordinates import Observatory
 
 ALL_CHANNELS = "all channels"
 

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -12,10 +12,16 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
 from astropy.units.quantity import Quantity
 from IPython.display import HTML, display
+
+from ..coordinates import (
+    Observatory,
+    crval4_to_pol,
+)
 
 ALL_CHANNELS = "all channels"
 
@@ -779,3 +785,26 @@ def inner_channel_slice(nchan: int, fedge: float = 0.1) -> slice:
     start = round(nchan * fedge)
     stop = -(start - 1)
     return slice(start, stop, 1)
+
+def coord_formatter(s,frame='fk5',fmt='hmsdms'):
+    sc = SkyCoord(
+        s.meta["CRVAL2"],
+        s.meta["CRVAL3"],
+        unit="deg",
+        frame=s.meta["RADESYS"].lower(),
+        obstime=s._obstime,
+        location=Observatory.get_earth_location(s.meta["SITELONG"], s.meta["SITELAT"], s.meta["SITEELEV"]),
+    )
+    if fmt=='decimal':
+        out_str = sc.transform_to(frame).to_string(fmt, precision=3)
+    else:
+        out_str = sc.transform_to(frame).to_string(fmt, sep=" ", precision=2)[:-1]
+    out_ra = out_str[:11]
+    out_dec = out_str[12:]
+    return out_ra, out_dec
+
+def time_formatter(time_sec):
+    hh = int(time_sec // 3600)
+    mm = int((time_sec - 3600 * hh) // 60)
+    ss = np.around((time_sec - 3600 * hh - 60 * mm), 1)
+    return f"{str(hh).zfill(2)} {str(mm).zfill(2)} {str(ss).zfill(3)}"

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -791,7 +791,7 @@ def coord_formatter(s, frame="fk5", fmt="hmsdms"):
         unit="deg",
         frame=s.meta["RADESYS"].lower(),
         obstime=s._obstime,
-        location=Observatory.get_earth_location(s.meta["SITELONG"], s.meta["SITELAT"], s.meta["SITEELEV"]),
+        location=Observatory[s.meta["TELESCOP"]],
     )
     if fmt == "decimal":
         out_str = sc.transform_to(frame).to_string(fmt, precision=3)
@@ -807,3 +807,9 @@ def time_formatter(time_sec):
     mm = int((time_sec - 3600 * hh) // 60)
     ss = np.around((time_sec - 3600 * hh - 60 * mm), 1)
     return f"{str(hh).zfill(2)} {str(mm).zfill(2)} {str(ss).zfill(3)}"
+
+
+def utc_formatter(ut):
+    dt = ut.split("_")
+    out = f"{dt[3]}  {dt[0]}-{dt[1]}-{dt[2]}"
+    return out

--- a/src/dysh/util/core.py
+++ b/src/dysh/util/core.py
@@ -785,14 +785,17 @@ def inner_channel_slice(nchan: int, fedge: float = 0.1) -> slice:
 
 
 def coord_formatter(s, frame="fk5", fmt="hmsdms"):
-    sc = SkyCoord(
-        s.meta["CRVAL2"],
-        s.meta["CRVAL3"],
-        unit="deg",
-        frame=s.meta["RADESYS"].lower(),
-        obstime=s._obstime,
-        location=Observatory[s.meta["TELESCOP"]],
-    )
+    if hasattr(s, "target"):
+        sc = s.target
+    else:
+        sc = SkyCoord(
+            s.meta["CRVAL2"],
+            s.meta["CRVAL3"],
+            unit="deg",
+            frame=s.meta["RADESYS"].lower(),
+            obstime=s._obstime,
+            location=Observatory[s.meta["TELESCOP"]],
+        )
     if fmt == "decimal":
         out_str = sc.transform_to(frame).to_string(fmt, precision=3).split(" ")
         out_ra, out_dec = out_str[0], out_str[1]


### PR DESCRIPTION
Repost for merging into `release-1.1`.

Feature for https://github.com/GreenBankObservatory/dysh/issues/474.

We should address the intnum at some point, and this could definitely be refactored for a ScanBlock header(), but I didn't want to think about how the information about N scans could be distilled. This is the simplest version of a header, just for spectrum objects.