### PR TITLE
Add MJD-OBS to Spectrum.meta when only DATE-OBS is present

### DIFF
--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -124,6 +124,8 @@ class Spectrum(Spectrum1D, HistoricalBase):
             self._obstime = Time(self.meta["MJD-OBS"])
         else:
             self._obstime = None
+        if self._obstime is not None and "MJD-OBS" not in self.meta:
+            self.meta["MJD-OBS"] = self._obstime.mjd
         self._spectral_axis._observer = self.observer
         if self._spectral_axis._observer is not None:
             self._velocity_frame = self._spectral_axis._observer.name

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -5,6 +5,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.time import Time
 
 from dysh.coordinates import Observatory
 from dysh.fits.gbtfitsload import GBTFITSLoad
@@ -950,6 +951,43 @@ class TestSpectrum:
             data=np.arange(64) * u.K, meta=meta, use_wcs=True, observer_location=Observatory["GBT"]
         )
         assert s.meta["RADESYS"] == meta["RADECSYS"]
+
+    def test_mjd_obs_from_date_obs(self):
+        """Test that MJD-OBS is computed from DATE-OBS when not already present."""
+        meta = {
+            "CTYPE4": "Stokes",
+            "CTYPE3": "DEC",
+            "CTYPE2": "RA",
+            "CTYPE1": "FREQ-OBS",
+            "EQUINOX": 2000.0,
+            "VELOCITY": 0.0,
+            "CUNIT1": "Hz",
+            "CUNIT2": "deg",
+            "CUNIT3": "deg",
+            "CRVAL1": 1e9,
+            "CDELT1": 0.1e9,
+            "CRPIX1": 1,
+            "CRVAL2": 121.0,
+            "CRVAL3": 15.0,
+            "CRVAL4": -1,
+            "RADECSYS": "FK5",
+            "VELDEF": "OPTI-HEL",
+            "DATE-OBS": "2021-02-10T07:38:37.50",
+            "RESTFRQ": 1e9,
+        }
+        s = Spectrum.make_spectrum(
+            data=np.arange(64) * u.K, meta=meta, use_wcs=True, observer_location=Observatory["GBT"]
+        )
+        assert "MJD-OBS" in s.meta
+        expected_mjd = Time("2021-02-10T07:38:37.50").mjd
+        assert s.meta["MJD-OBS"] == expected_mjd
+
+        # When MJD-OBS is already present, it should not be overwritten.
+        meta["MJD-OBS"] = 59999.0
+        s2 = Spectrum.make_spectrum(
+            data=np.arange(64) * u.K, meta=meta, use_wcs=True, observer_location=Observatory["GBT"]
+        )
+        assert s2.meta["MJD-OBS"] == 59999.0
 
     def test_get_selected_regions(self):
         """


### PR DESCRIPTION
## Summary
- Fixes #490: When a `Spectrum` has `DATE-OBS` but no `MJD-OBS` in its metadata, compute `MJD-OBS` from `_obstime.mjd` and store it in `meta`
- Existing `MJD-OBS` values are not overwritten
- Adds test covering both cases

## Test plan
- [x] `test_mjd_obs_from_date_obs` verifies MJD-OBS is computed from DATE-OBS
- [x] Test verifies existing MJD-OBS is preserved when already present

🤖 Generated with [Claude Code](https://claude.ai/code)