### PR TITLE
Fix LazyFlagArray memmap temp file cleanup (#1089)

### DIFF
--- a/src/dysh/fits/lazyflag.py
+++ b/src/dysh/fits/lazyflag.py
@@ -9,6 +9,7 @@ from ~40GB to a few MB (proportional to flagged rows only).
 import atexit
 import gc
 import os
+import shutil
 import tempfile
 import weakref
 
@@ -370,6 +371,17 @@ class LazyFlagArray:
 
         if use_memmap:
             logger.info(f"LazyFlagArray.to_dense: using memmap for {estimated_bytes / 1024**3:.1f} GB array")
+            tmpdir = tempfile.gettempdir()
+            try:
+                free_bytes = shutil.disk_usage(tmpdir).free
+            except OSError:
+                free_bytes = None
+            if free_bytes is not None and free_bytes < estimated_bytes:
+                logger.warning(
+                    f"LazyFlagArray.to_dense: only {free_bytes / 1024**3:.1f} GB free in {tmpdir}, "
+                    f"but need {estimated_bytes / 1024**3:.1f} GB for memmap; "
+                    f"creation may fail or exhaust disk"
+                )
             tmpfile = tempfile.NamedTemporaryFile(suffix=".flags", delete=False)
             tmpfile.close()
             self._tempfiles.append(tmpfile.name)

--- a/src/dysh/fits/lazyflag.py
+++ b/src/dysh/fits/lazyflag.py
@@ -6,7 +6,10 @@ For a 77GB file (~1.2M rows x 16384 channels), this reduces flag memory
 from ~40GB to a few MB (proportional to flagged rows only).
 """
 
+import atexit
+import os
 import tempfile
+import weakref
 
 import numpy as np
 from astropy.io import fits
@@ -71,6 +74,33 @@ class LazyFlagArray:
         # Deduplicated mask pool: bytes(mask) -> mask array.
         # Multiple rows can reference the same mask object when patterns repeat.
         self._mask_pool = {}
+        # Track temp files created by to_dense() for cleanup
+        self._tempfiles = []
+        # Register atexit cleanup via weak reference so we don't prevent GC
+        weak_self = weakref.ref(self)
+        atexit.register(LazyFlagArray._atexit_cleanup, weak_self)
+
+    def cleanup(self):
+        """Remove all temporary memmap files created by to_dense()."""
+        for path in self._tempfiles:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self._tempfiles.clear()
+
+    def __del__(self):
+        try:
+            self.cleanup()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _atexit_cleanup(weak_self):
+        """Atexit handler that cleans up temp files if the object still exists."""
+        self = weak_self()
+        if self is not None:
+            self.cleanup()
 
     @property
     def shape(self):
@@ -330,6 +360,7 @@ class LazyFlagArray:
             logger.info(f"LazyFlagArray.to_dense: using memmap for {estimated_bytes / 1024**3:.1f} GB array")
             tmpfile = tempfile.NamedTemporaryFile(suffix=".flags", delete=False)
             tmpfile.close()
+            self._tempfiles.append(tmpfile.name)
             result = np.memmap(tmpfile.name, dtype=bool, mode="w+", shape=(self._nrows, self._nchan))
         else:
             result = np.zeros((self._nrows, self._nchan), dtype=bool)

--- a/src/dysh/fits/lazyflag.py
+++ b/src/dysh/fits/lazyflag.py
@@ -7,6 +7,7 @@ from ~40GB to a few MB (proportional to flagged rows only).
 """
 
 import atexit
+import gc
 import os
 import tempfile
 import weakref
@@ -81,13 +82,24 @@ class LazyFlagArray:
         atexit.register(LazyFlagArray._atexit_cleanup, weak_self)
 
     def cleanup(self):
-        """Remove all temporary memmap files created by to_dense()."""
+        """Remove all temporary memmap files created by to_dense().
+
+        On Windows, a file backing an open memmap cannot be deleted, so we
+        force a GC pass to release any memmaps that are only held by
+        finalizer-tracked references before attempting removal.
+        """
+        if not self._tempfiles:
+            return
+        gc.collect()
+        remaining = []
         for path in self._tempfiles:
             try:
                 os.unlink(path)
-            except OSError:
+            except FileNotFoundError:
                 pass
-        self._tempfiles.clear()
+            except OSError:
+                remaining.append(path)
+        self._tempfiles = remaining
 
     def __del__(self):
         try:

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -347,7 +347,6 @@ class TestLazyFlagCleanup:
     def test_low_disk_warning(self, caplog, monkeypatch):
         """A warning is logged when tempdir free space < estimated_bytes."""
         import shutil as _shutil
-
         from collections import namedtuple
 
         Usage = namedtuple("Usage", ["total", "used", "free"])

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -343,3 +343,18 @@ class TestLazyFlagCleanup:
         del dense
         arr.cleanup()
         arr.cleanup()  # should not raise
+
+    def test_low_disk_warning(self, caplog, monkeypatch):
+        """A warning is logged when tempdir free space < estimated_bytes."""
+        import shutil as _shutil
+
+        from collections import namedtuple
+
+        Usage = namedtuple("Usage", ["total", "used", "free"])
+        monkeypatch.setattr(_shutil, "disk_usage", lambda _p: Usage(100, 100, 0))
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        with caplog.at_level("WARNING", logger="dysh"):
+            dense = arr.to_dense()
+        del dense
+        arr.cleanup()
+        assert any("free in" in rec.message and "memmap" in rec.message for rec in caplog.records)

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -1,5 +1,7 @@
 """Tests for LazyFlagArray and LazyFlagContainer."""
 
+import os
+
 import numpy as np
 import pytest
 
@@ -304,3 +306,36 @@ class TestLazyFlagContainer:
         """LazyFlagContainer should be truthy (not None)."""
         c = LazyFlagContainer(1)
         assert c is not None
+
+
+class TestLazyFlagCleanup:
+    """Tests for temporary file cleanup (issue #1089)."""
+
+    def test_to_dense_memmap_cleanup(self):
+        """Temp files created by to_dense() are removed by cleanup()."""
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        arr.or_rows([0], np.ones(100, dtype=bool))
+        dense = arr.to_dense()
+        assert isinstance(dense, np.memmap)
+        assert len(arr._tempfiles) == 1
+        path = arr._tempfiles[0]
+        assert os.path.exists(path)
+        arr.cleanup()
+        assert not os.path.exists(path)
+        assert len(arr._tempfiles) == 0
+
+    def test_del_cleans_up_tempfiles(self):
+        """Temp files are removed when the object is deleted."""
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        arr.to_dense()
+        path = arr._tempfiles[0]
+        assert os.path.exists(path)
+        del arr
+        assert not os.path.exists(path)
+
+    def test_cleanup_idempotent(self):
+        """Calling cleanup() multiple times is safe."""
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        arr.to_dense()
+        arr.cleanup()
+        arr.cleanup()  # should not raise

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -320,6 +320,8 @@ class TestLazyFlagCleanup:
         assert len(arr._tempfiles) == 1
         path = arr._tempfiles[0]
         assert os.path.exists(path)
+        # Release the memmap reference (required on Windows before unlink)
+        del dense
         arr.cleanup()
         assert not os.path.exists(path)
         assert len(arr._tempfiles) == 0
@@ -327,15 +329,17 @@ class TestLazyFlagCleanup:
     def test_del_cleans_up_tempfiles(self):
         """Temp files are removed when the object is deleted."""
         arr = LazyFlagArray(10, 100, memmap_threshold=0)
-        arr.to_dense()
+        dense = arr.to_dense()
         path = arr._tempfiles[0]
         assert os.path.exists(path)
+        del dense
         del arr
         assert not os.path.exists(path)
 
     def test_cleanup_idempotent(self):
         """Calling cleanup() multiple times is safe."""
         arr = LazyFlagArray(10, 100, memmap_threshold=0)
-        arr.to_dense()
+        dense = arr.to_dense()
+        del dense
         arr.cleanup()
         arr.cleanup()  # should not raise


### PR DESCRIPTION
## Summary
- `LazyFlagArray.to_dense()` created memmap-backed temp files with `delete=False` but never cleaned them up, gradually filling `/tmp` and eventually crashing Jupyter kernels
- Track temp file paths on the instance and clean them up via `cleanup()`, `__del__`, and an `atexit` handler (using `weakref` to avoid preventing GC)
- Added tests for cleanup, deletion, and idempotent cleanup calls

Fixes #1089

## Test plan
- [x] All existing `test_lazyflag.py` tests pass (35/35)
- [x] New `TestLazyFlagCleanup` tests verify temp files are created and removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)