### PR TITLE
Fix issue #1091: fitsio writer now persists in-memory DATA mutations

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -214,15 +214,12 @@ def _build_chunk_recarray(sdf, bintable_idx, chunk_rows, col_names, include_flag
         for name in mem_only_cols:
             chunk[name] = bt_data[name][chunk_rows]
 
-    # If astropy .data was previously loaded, overlay scalar disk columns from memory
-    # to capture any mutations from sdf["COLNAME"] = value.
-    # DATA is never mutated so we always keep the fitsio version.
+    # If astropy .data was previously loaded, overlay disk columns from memory
+    # to capture any mutations from sdf["COLNAME"] = value (including DATA).
     if data_loaded:
         if not mem_only_cols:
             bt_data = bt.data
         for name in disk_cols:
-            if name == "DATA":
-                continue
             chunk[name] = bt_data[name][chunk_rows]
 
     if include_flags:

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -1048,6 +1048,26 @@ class TestGBTFITSLoad:
             f = util.get_project_testdata() / "AGBT18B_354_03/AGBT18B_354_03.raw.vegas/"
             g = gbtfitsload.GBTFITSLoad(f)
 
+    @pytest.mark.parametrize("has_fitsio", [True, False])
+    def test_write_mutated_data(self, tmp_path, monkeypatch, has_fitsio):
+        """Regression test for issue #1091: writing must persist in-memory DATA mutations
+        on both the fitsio and astropy code paths."""
+        if has_fitsio and not HAS_FITSIO:
+            pytest.skip("fitsio not installed")
+        monkeypatch.setattr(gbtfitsload, "HAS_FITSIO", has_fitsio)
+
+        f = util.get_project_testdata() / "AGBT18B_354_03/AGBT18B_354_03.raw.vegas/AGBT18B_354_03.raw.vegas.A.fits"
+        sdf = gbtfitsload.GBTFITSLoad(f, index_file_threshold=100000000)
+        new_data = np.ones(sdf["DATA"].shape, dtype=sdf["DATA"].dtype)
+        with pytest.warns(UserWarning):
+            sdf["DATA"] = new_data
+
+        out = tmp_path / f"mutated_data_{has_fitsio}.fits"
+        sdf.write(out, overwrite=True, flags=False)
+
+        sdf2 = gbtfitsload.GBTFITSLoad(out, index_file_threshold=100000000)
+        assert np.array_equal(sdf2["DATA"], new_data)
+
     def test_azel_coords(self, tmp_path):
         """
         Test that observations using AzEl coordinates can produce a valid `Spectrum`.


### PR DESCRIPTION
## Summary
- `_build_chunk_recarray` explicitly skipped the DATA column when overlaying in-memory mutations, on the false assumption that DATA is never mutated. `sdf["DATA"] = ...` does mutate it, so writes via the fitsio path silently lost those updates.
- Removed the DATA skip so the fitsio path now matches the astropy path's behavior.
- Added a regression test parametrized over both write paths via a monkeypatched `HAS_FITSIO`.

Fixes #1091.

## Test plan
- [x] New test `test_write_mutated_data[True]` (fitsio path) passes
- [x] New test `test_write_mutated_data[False]` (astropy path) passes
- [x] Full `src/dysh/fits/tests/test_gbtfitsload.py` suite: 86 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)