### PR TITLE
Fix log decorators dropping kwargs and stripping string quotes (#1108)

### DIFF
--- a/src/dysh/log.py
+++ b/src/dysh/log.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import logging.config
 import os
@@ -214,9 +213,6 @@ def log_function_call(log_level: str = "info"):
         except KeyError:
             raise Exception(f"Log level {log_level} unrecognized. Must be one of {list(logging._nameToLevel.keys())}.")  # noqa: B904
 
-        # Cache signature at decoration time for performance
-        sig = inspect.signature(func)
-
         @wraps(func)
         def func_wrapper(*args, **kwargs):
             try:
@@ -231,9 +227,8 @@ def log_function_call(log_level: str = "info"):
                 # func is  method of a class
                 logmsg += f"{func.__self__.__class__.__name__}"
             logmsg += f".{func.__name__}{args}"
-            if "kwargs" in sig.parameters:
-                for k, v in kwargs.items():
-                    logmsg += f"{k}={v},"
+            for k, v in kwargs.items():
+                logmsg += f"{k}={v!r},"
             logmsg = ensure_ascii(logmsg)
             logger.log(level=ilog_level, msg=logmsg)
             return result
@@ -271,11 +266,11 @@ def format_dysh_log_record(record: logging.LogRecord) -> str:
     logmsg += f"{record.fName}("
     if len(record.args) > 0:
         for a in record.args:
-            logmsg += f"{a},"
+            logmsg += f"{a!r},"
     if hasattr(record, "kwargs"):
         if len(record.kwargs) > 0:
             for k, v in record.kwargs.items():
-                logmsg += f"{k}={v},"
+                logmsg += f"{k}={v!r},"
     logmsg += ")"
     return ensure_ascii(logmsg)
 
@@ -300,9 +295,6 @@ def log_call_to_result(func: Callable):
     # If logging is disabled, return the function unchanged
     if DISABLE_HISTORY_LOGGING:
         return func
-
-    # Cache signature at decoration time for performance
-    sig = inspect.signature(func)
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -333,8 +325,7 @@ def log_call_to_result(func: Callable):
                     "modName": func.__module__,
                     "fName": func.__name__,
                 }
-            if "kwargs" in sig.parameters:
-                extra["kwargs"] = kwargs
+            extra["kwargs"] = kwargs
             with dhlogger.log_to_list() as log_list:
                 dhlogger.info(f"DYSH v{dysh_version}", *args, extra=extra)
                 log_str = [format_dysh_log_record(i) for i in log_list]
@@ -368,9 +359,6 @@ def log_call_to_history(func: Callable):
     if DISABLE_HISTORY_LOGGING:
         return func
 
-    # Cache signature at decoration time for performance
-    sig = inspect.signature(func)
-
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         if self is None:  # not a class, but a function
@@ -394,15 +382,12 @@ def log_call_to_history(func: Callable):
                 raise exc.with_traceback(tb.tb_next) from None
             classname = self.__class__.__name__
             if hasattr(self, "_history"):
-                if "kwargs" in sig.parameters:
-                    extra = {
-                        "modName": func.__module__,
-                        "className": classname,
-                        "fName": func.__name__,
-                        "kwargs": kwargs,
-                    }
-                else:
-                    extra = {"modName": func.__module__, "className": classname, "fName": func.__name__, "extra": {}}
+                extra = {
+                    "modName": func.__module__,
+                    "className": classname,
+                    "fName": func.__name__,
+                    "kwargs": kwargs,
+                }
                 with dhlogger.log_to_list() as log_list:
                     dhlogger.info(f"DYSH v{dysh_version}", *args, extra=extra)
                     log_str = [format_dysh_log_record(i) for i in log_list]

--- a/src/dysh/tests/test_log.py
+++ b/src/dysh/tests/test_log.py
@@ -1,0 +1,37 @@
+"""
+Regression tests for the history-logging decorators in :mod:`dysh.log`.
+
+See https://github.com/GreenBankObservatory/dysh/issues/1108
+"""
+
+from dysh.spectra import Spectrum
+
+
+def _smooth_history_entries(spec):
+    return [h for h in spec._history if "smooth(" in h]
+
+
+def test_log_call_to_history_positional_args_recorded():
+    """Positional args (including strings) are recorded with quotes preserved."""
+    s = Spectrum.fake_spectrum()
+    s.smooth("gaussian", 5)
+    entries = _smooth_history_entries(s)
+    assert len(entries) == 1
+    assert "smooth('gaussian',5,)" in entries[0]
+
+
+def test_log_call_to_history_keyword_args_recorded():
+    """Keyword args are recorded even when the function has no ``**kwargs``."""
+    s = Spectrum.fake_spectrum()
+    s.smooth(kernel="gaussian", width=5)
+    entries = _smooth_history_entries(s)
+    assert len(entries) == 1
+    assert "smooth(kernel='gaussian',width=5,)" in entries[0]
+
+
+def test_log_call_to_result_keyword_args_recorded():
+    """The result's _history records keyword args (covers @log_call_to_result paths)."""
+    s = Spectrum.fake_spectrum()
+    q = s.smooth(kernel="gaussian", width=5)
+    entries = _smooth_history_entries(q)
+    assert any("smooth(kernel='gaussian',width=5,)" in h for h in entries)


### PR DESCRIPTION
## Summary
- Fixes #1108. The history-logging decorators (`@log_call_to_history`, `@log_call_to_result`, `@log_function_call`) gated kwargs logging on `"kwargs" in sig.parameters`, which is only true when the decorated function literally declares `**kwargs`. Methods like `Spectrum.smooth(kernel=..., width=...)` had their kwargs silently dropped from history. The check is removed; caller-supplied kwargs are always logged.
- `format_dysh_log_record` and `log_function_call` now use `repr()` for arg/kwarg values, so string arguments retain their quotes (`'gaussian'` instead of `gaussian`).
- Drops the now-unused `inspect` import and signature caches.

## Test plan
- [x] New `src/dysh/tests/test_log.py` covers positional, keyword, and result-side keyword call forms from the issue (3 passed).
- [x] `uv run pytest src/dysh/spectra/tests/test_spectrum.py` — 44 passed.
- [x] `uv run pytest src/dysh/spectra/tests/test_scan.py` — 42 passed, 1 skipped (pre-existing).
- [x] `uv run ruff check src/dysh/log.py src/dysh/tests/test_log.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)