### PR TITLE
1100 defining regions for basleine fitting doesnt work

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -153,6 +153,41 @@ Plot again, but focus on the line-free regions:
 
 .. image:: files/spectrum_plot_bsub.png
 
+
+Using Exclude Regions
+--------------------------------
+
+When you give an ``exclude`` value to ``baseline``, the default behavior is to store it in the `exclude_regions <dysh.spectra.spectrum.Spectrum.exclude_regions>` property, which is a list of `SpectralRegions <astropy.coordinate.SpectralRegion>`.   Subsequent baseline operations on the spectrum can reuse these exclude regions, append to them, or ignore them, depending on the value of the ``exclude_action`` keyword. Options are:
+
+        - "replace" : replace the `Spectrum.exclude_regions` list with the input region. 
+        - "append" : append the input region to the `Spectrum.exclude_regions` list.
+        - None      : Use the the input region, but do not change the existing `Spectrum.exclude_regions`
+
+
+The default is "replace."   Below is example usage.
+
+.. code:: Python
+
+    s = Spectrum.fake_spectrum(1024)
+    exclude1 = [(1,100)]
+    exclude2 = [(924,1024)]
+
+    # The input exclude regions are used in the baseline and are stored in the Spectrum.
+    s.baseline(degree=1,exclude=exclude1)
+
+    # The input exclude regions are used and replace the previously stored regions.
+    s.baseline(degree=1,exclude=exclude2)
+
+    # The input exclude regions are appended to the stored regions.
+    s.baseline(degree=1,exclude=exclude1, exclude_action="append")
+
+    # The input exclude regions are used but the stored regions are unaffected.
+    s.baseline(degree=1,exclude=exclude2, exclude_action=None)
+
+    # The input exclude regions are used and replace the previously stored regions.
+    s.baseline(degree=1,exclude=exclude1, exclude_action="replace")
+
+
 Polarization Average
 ====================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -159,7 +159,7 @@ Using Exclude Regions
 
 When you give an ``exclude`` value to ``baseline``, the default behavior is to store it in the `exclude_regions <dysh.spectra.spectrum.Spectrum.exclude_regions>` property, which is a list of `SpectralRegions <astropy.coordinate.SpectralRegion>`.   Subsequent baseline operations on the spectrum can reuse these exclude regions, append to them, or ignore them, depending on the value of the ``exclude_action`` keyword. Options are:
 
-        - "replace" : replace the `Spectrum.exclude_regions` list with the input region. 
+        - "replace" : replace the `Spectrum.exclude_regions` list with the input region.
         - "append" : append the input region to the `Spectrum.exclude_regions` list.
         - None      : Use the the input region, but do not change the existing `Spectrum.exclude_regions`
 

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -534,7 +534,7 @@ def baseline(
     order,
     exclude=None,
     model="chebyshev",
-    fitter=LinearLSQFitter(calc_uncertainties=True),
+    fitter=None, 
     exclude_region_upper_bounds=True,
     clip_exclude=True,
     exclude_action="replace",
@@ -606,6 +606,8 @@ def baseline(
     model = minimum_string_match(model, list(available_models.keys()))
     if model is None:
         raise ValueError(f"Unrecognized input model {model}. Must be one of {list(available_models.keys())}")
+    if fitter is None:
+        fitter = LinearLSQFitter(calc_uncertainties=True)
     sa_min = spectrum.spectral_axis.min().value
     sa_max = spectrum.spectral_axis.max().value
     selected_model = available_models[model](degree=order, domain=(sa_max, sa_min))

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -529,8 +529,16 @@ def clip_spectral_region_subregions(spectral_region, spectrum):
             spectral_region._subregions[i] = (s[0], sa_max)
 
 
-def baseline(spectrum, order, exclude=None, model = "chebyshev", fitter = LinearLSQFitter(calc_uncertainties=True),
-             exclude_region_upper_bounds=True, clip_exclude=True, exclude_action="replace"):
+def baseline(
+    spectrum,
+    order,
+    exclude=None,
+    model="chebyshev",
+    fitter=LinearLSQFitter(calc_uncertainties=True),
+    exclude_region_upper_bounds=True,
+    clip_exclude=True,
+    exclude_action="replace",
+):
     """Fit a baseline to `spectrum`.
     The code uses `~astropy.modeling.fitting.Fitter` and `~astropy.modeling.polynomial` to compute the baseline.
     See the documentation for those modules for details.
@@ -575,13 +583,13 @@ def baseline(spectrum, order, exclude=None, model = "chebyshev", fitter = Linear
         Whether to clip the exclude or include regions when they extend outside the `spectrum.spectral_axis`.
     exclude_action : str
         How to combine the input exclude region with any existing exclude regions in the input `Spectrum`. Options are
-            
+
             - "replace" : replace the `Spectrum` exclude regions with the input region
-            - "append"  : append the input region to the `Spectrum` exclude region list. 
+            - "append"  : append the input region to the `Spectrum` exclude region list.
             -  None    : Use the `Spectrum`'s exclude regions, ignoring the input region.
-     
+
         Default: "replace"
-            
+
     Returns
     -------
     model : `~specutils.utils.QuantityModel`

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -586,7 +586,7 @@ def baseline(
 
             - "replace" : replace the `Spectrum` exclude regions with the input region
             - "append"  : append the input region to the `Spectrum` exclude region list.
-            -  None    : Use the `Spectrum`'s exclude regions, ignoring the input region.
+            - None      : Use the the input region, but do not change the existing `Spectrum.exclude_regions`
 
         Default: "replace"
 
@@ -628,12 +628,13 @@ def baseline(
         elif exclude_action == "append":
             p._exclude_regions.extend(regionlist)
             regionlist = p._exclude_regions
+        #if exclude is None, we do not touch the existing Spectrum.exclude_regions`
     else:
         # use the spectrum's preset exclude regions if they
         # exist (they will be a list of SpectralRegions or None)
         regionlist = p._exclude_regions
 
-    logger.info(f"EXCLUDING {regionlist}")
+    logger.debug(f"EXCLUDING {regionlist}")
 
     fitted_model = fit_continuum(
         spectrum=p,

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -628,7 +628,7 @@ def baseline(
         elif exclude_action == "append":
             p._exclude_regions.extend(regionlist)
             regionlist = p._exclude_regions
-        #if exclude is None, we do not touch the existing Spectrum.exclude_regions`
+        # if exclude is None, we do not touch the existing Spectrum.exclude_regions`
     else:
         # use the spectrum's preset exclude regions if they
         # exist (they will be a list of SpectralRegions or None)

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -534,7 +534,7 @@ def baseline(
     order,
     exclude=None,
     model="chebyshev",
-    fitter=None, 
+    fitter=None,
     exclude_region_upper_bounds=True,
     clip_exclude=True,
     exclude_action="replace",

--- a/src/dysh/spectra/core.py
+++ b/src/dysh/spectra/core.py
@@ -529,7 +529,8 @@ def clip_spectral_region_subregions(spectral_region, spectrum):
             spectral_region._subregions[i] = (s[0], sa_max)
 
 
-def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **kwargs):
+def baseline(spectrum, order, exclude=None, model = "chebyshev", fitter = LinearLSQFitter(calc_uncertainties=True),
+             exclude_region_upper_bounds=True, clip_exclude=True, exclude_action="replace"):
     """Fit a baseline to `spectrum`.
     The code uses `~astropy.modeling.fitting.Fitter` and `~astropy.modeling.polynomial` to compute the baseline.
     See the documentation for those modules for details.
@@ -563,7 +564,7 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
         Default: no exclude region
 
     model : str
-        One of 'polynomial' or 'chebyshev', Default: 'polynomial'
+        One of 'chebyshev', 'hermite', 'legendre', 'polynomial'.  Default: 'chebyshev'
     fitter : `~astropy.modeling.fitting.Fitter`
         The fitter to use. Default: `~astropy.modeling.fitter.LinearLSQFitter` (with `calc_uncertaintes=True`).
         Be careful when choosing a different fitter to be sure it is optimized for this problem.
@@ -572,20 +573,21 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
         Allows excising channel 0 for lower-sideband data, and the last channel for upper-sideband data.
     clip_exclude : bool
         Whether to clip the exclude or include regions when they extend outside the `spectrum.spectral_axis`.
-
+    exclude_action : str
+        How to combine the input exclude region with any existing exclude regions in the input `Spectrum`. Options are
+            
+            - "replace" : replace the `Spectrum` exclude regions with the input region
+            - "append"  : append the input region to the `Spectrum` exclude region list. 
+            -  None    : Use the `Spectrum`'s exclude regions, ignoring the input region.
+     
+        Default: "replace"
+            
     Returns
     -------
     model : `~specutils.utils.QuantityModel`
         Best fit model.
         See `~specutils.fitting.fit_continuum`.
     """
-    kwargs_opts = {
-        "model": "chebyshev",
-        "fitter": LinearLSQFitter(calc_uncertainties=True),
-        "clip_exclude": True,
-        "exclude_action": "replace",
-    }
-    kwargs_opts.update(kwargs)
 
     available_models = {
         "chebyshev": Chebyshev1D,
@@ -593,28 +595,27 @@ def baseline(spectrum, order, exclude=None, exclude_region_upper_bounds=True, **
         "legendre": Legendre1D,
         "polynomial": Polynomial1D,
     }
-    model = minimum_string_match(kwargs_opts["model"], list(available_models.keys()))
+    model = minimum_string_match(model, list(available_models.keys()))
     if model is None:
-        raise ValueError(f"Unrecognized input model {kwargs['model']}. Must be one of {list(available_models.keys())}")
+        raise ValueError(f"Unrecognized input model {model}. Must be one of {list(available_models.keys())}")
     sa_min = spectrum.spectral_axis.min().value
     sa_max = spectrum.spectral_axis.max().value
     selected_model = available_models[model](degree=order, domain=(sa_max, sa_min))
 
     _valid_exclude_actions = ["replace", "append", None]
-    if kwargs_opts["exclude_action"] not in _valid_exclude_actions:
+    if exclude_action not in _valid_exclude_actions:
         raise ValueError(
-            f"Unrecognized exclude region action {kwargs['exclude_region']}. Must be one of {_valid_exclude_actions}"
+            f"Unrecognized exclude region action {exclude_action}. Must be one of {_valid_exclude_actions}"
         )
-    fitter = kwargs_opts["fitter"]
     p = spectrum
     if np.isnan(p.data).all():
         # @todo handle masks
         return None  # or raise exception
     if exclude is not None:
-        regionlist = exclude_to_region_list(exclude, spectrum, clip_exclude=kwargs_opts["clip_exclude"])
-        if kwargs_opts["exclude_action"] == "replace":
+        regionlist = exclude_to_region_list(exclude, spectrum, clip_exclude=clip_exclude)
+        if exclude_action == "replace":
             p._exclude_regions = regionlist
-        elif kwargs_opts["exclude_action"] == "append":
+        elif exclude_action == "append":
             p._exclude_regions.extend(regionlist)
             regionlist = p._exclude_regions
     else:

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -260,7 +260,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
 
                 - "replace" : replace the `Spectrum.exclude_regions` list with the input region
                 - "append"  : append the input region to the `Spectrum.exclude_regions` list.
-                - None      : Use the existing `Spectrum.exclude_regions`, ignoring the input region.
+                - None      : Use the the input region, but do not change the existing `Spectrum.exclude_regions`
 
             Default: "replace"
         color : str

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -238,8 +238,6 @@ class Spectrum(Spectrum1D, HistoricalBase):
         remove : bool
             If True, the baseline is removed from the spectrum.
             If False, the baseline will be computed and overlaid on the spectrum. Default: False
-        color : str
-            The color to plot the baseline model, if remove=False. Can be any type accepted by matplotlib.
         exclude_region_upper_bounds : bool
             Makes the upper bound of any excision region(s) inclusive.
             Allows excising channel 0 for lower-sideband data, and the last channel for upper-sideband data.
@@ -248,11 +246,13 @@ class Spectrum(Spectrum1D, HistoricalBase):
         exclude_action : str
             How to combine the input exclude region with any existing exclude regions in the input `Spectrum`. Options are
                 
-                - "replace" : replace the `Spectrum` exclude regions with the input region
-                - "append"  : append the input region to the `Spectrum` exclude region list. 
-                - None      : Use the `Spectrum`'s exclude regions, ignoring the input region.
+                - "replace" : replace the `Spectrum.exclude_regions` list with the input region
+                - "append"  : append the input region to the `Spectrum.exclude_regions` list. 
+                - None      : Use the existing `Spectrum.exclude_regions`, ignoring the input region.
                 
             Default: "replace"
+        color : str
+            The color to plot the baseline model, if remove=False. Can be any type accepted by matplotlib.
      
         """
         # fmt: on

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -198,7 +198,19 @@ class Spectrum(Spectrum1D, HistoricalBase):
         return Masked(self.data * self.unit, mask=self.mask).filled(np.nan)
 
     @log_call_to_history
-    def baseline(self, degree, exclude=None, include=None,  remove=False,  model = "chebyshev", fitter = None ,exclude_region_upper_bounds=True, clip_exclude=True, exclude_action="replace", color="k"):
+    def baseline(
+        self,
+        degree,
+        exclude=None,
+        include=None,
+        remove=False,
+        model="chebyshev",
+        fitter=None,
+        exclude_region_upper_bounds=True,
+        clip_exclude=True,
+        exclude_action="replace",
+        color="k",
+    ):
         # fmt: off
         """
         Compute and optionally remove a baseline.
@@ -245,15 +257,15 @@ class Spectrum(Spectrum1D, HistoricalBase):
             Whether to clip the exclude or include regions when they extend outside the `spectrum.spectral_axis`.
         exclude_action : str
             How to combine the input exclude region with any existing exclude regions in the input `Spectrum`. Options are
-                
+
                 - "replace" : replace the `Spectrum.exclude_regions` list with the input region
-                - "append"  : append the input region to the `Spectrum.exclude_regions` list. 
+                - "append"  : append the input region to the `Spectrum.exclude_regions` list.
                 - None      : Use the existing `Spectrum.exclude_regions`, ignoring the input region.
-                
+
             Default: "replace"
         color : str
             The color to plot the baseline model, if remove=False. Can be any type accepted by matplotlib.
-     
+
         """
         # fmt: on
         if fitter is None:
@@ -264,8 +276,15 @@ class Spectrum(Spectrum1D, HistoricalBase):
             if exclude is not None:
                 logger.warning(f"Warning: ignoring exclude={exclude}")
             exclude = core.include_to_exclude_spectral_region(include, self)
-        self._baseline_model = baseline(self, order=degree, exclude=exclude, fitter=fitter,
-                                        model=model, exclude_action=exclude_action, clip_exclude=clip_exclude)
+        self._baseline_model = baseline(
+            self,
+            order=degree,
+            exclude=exclude,
+            fitter=fitter,
+            model=model,
+            exclude_action=exclude_action,
+            clip_exclude=clip_exclude,
+        )
         if remove:
             s = self.subtract(self._baseline_model(self.spectral_axis))
             self._data = s._data

--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -198,7 +198,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         return Masked(self.data * self.unit, mask=self.mask).filled(np.nan)
 
     @log_call_to_history
-    def baseline(self, degree, exclude=None, include=None, color="k", **kwargs):
+    def baseline(self, degree, exclude=None, include=None,  remove=False,  model = "chebyshev", fitter = None ,exclude_region_upper_bounds=True, clip_exclude=True, exclude_action="replace", color="k"):
         # fmt: off
         """
         Compute and optionally remove a baseline.
@@ -230,40 +230,48 @@ class Spectrum(Spectrum1D, HistoricalBase):
         include : list of 2-tuples of int or `~astropy.units.quantity.Quantity`, or `~specutils.SpectralRegion`
             List of region(s) to include in the fit. The tuple(s) represent a range in the form [lower,upper], inclusive.
             See `exclude` for examples.
-        color : str
-            The color to plot the baseline model, if remove=False. Can be any type accepted by matplotlib.
-        model : {'chebyshev', 'polynomial', 'legendre', 'hermite'}
-            Model to describe the baseline.
-            Default: 'chebyshev'
+        model : str
+            Model to describe the baseline. One of 'chebyshev', 'hermite', 'legendre', 'polynomial'.  Default: 'chebyshev'
         fitter : `~astropy.modeling.fitting.Fitter`
             The fitter to use. Default: `~astropy.modeling.fitting.LinearLSQFitter` (with `calc_uncertaintes=True`).
             Be careful when choosing a different fitter to be sure it is optimized for this problem.
         remove : bool
             If True, the baseline is removed from the spectrum.
             If False, the baseline will be computed and overlaid on the spectrum. Default: False
+        color : str
+            The color to plot the baseline model, if remove=False. Can be any type accepted by matplotlib.
+        exclude_region_upper_bounds : bool
+            Makes the upper bound of any excision region(s) inclusive.
+            Allows excising channel 0 for lower-sideband data, and the last channel for upper-sideband data.
+        clip_exclude : bool
+            Whether to clip the exclude or include regions when they extend outside the `spectrum.spectral_axis`.
+        exclude_action : str
+            How to combine the input exclude region with any existing exclude regions in the input `Spectrum`. Options are
+                
+                - "replace" : replace the `Spectrum` exclude regions with the input region
+                - "append"  : append the input region to the `Spectrum` exclude region list. 
+                - None      : Use the `Spectrum`'s exclude regions, ignoring the input region.
+                
+            Default: "replace"
+     
         """
         # fmt: on
-        # @todo: Are exclusion regions OR'd with the existing mask? make that an option?
-        kwargs_opts = {
-            "remove": False,
-            "model": "chebyshev",
-            "fitter": LinearLSQFitter(calc_uncertainties=True),
-        }
-        kwargs_opts.update(kwargs)
-
+        if fitter is None:
+            fitter = LinearLSQFitter(calc_uncertainties=True)
         # `include` and `exclude` are mutually exclusive, but we allow `include`
         # if `include` is used, transform it to `exclude`.
         if include is not None:
             if exclude is not None:
                 logger.warning(f"Warning: ignoring exclude={exclude}")
             exclude = core.include_to_exclude_spectral_region(include, self)
-        self._baseline_model = baseline(self, degree, exclude, **kwargs)
-        if kwargs_opts["remove"]:
+        self._baseline_model = baseline(self, order=degree, exclude=exclude, fitter=fitter,
+                                        model=model, exclude_action=exclude_action, clip_exclude=clip_exclude)
+        if remove:
             s = self.subtract(self._baseline_model(self.spectral_axis))
             self._data = s._data
             self._subtracted = True
         if self._plotter is not None:
-            if kwargs_opts["remove"]:
+            if remove:
                 self._plotter.set_ydata(self.flux, keep_unit=False)
                 self._plotter.clear_overlays(blines=True, oshows=False, catalog=False)
             else:

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -270,7 +270,7 @@ class TestSpectrum:
         # AND that order is preserved because
         # the baseline history should be the last entry
         # print(s.history)
-        assert "baseline(2,remove=True,)" in s.history[-1]
+        assert "baseline(2,remove=True)" in s.history[-1]
         print(s.comments)
         assert "I removed a baseline" in s.comments
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -270,7 +270,12 @@ class TestSpectrum:
         # AND that order is preserved because
         # the baseline history should be the last entry
         # print(s.history)
-        assert "baseline(2,remove=True)" in s.history[-1]
+        # **************************************************
+        # NOTE: This test is currently hacked to work pending
+        # merge of PR 1109. Once that is merged, this test
+        # must be updated to match the corrected output.
+        # **************************************************
+        assert "baseline(2,)" in s.history[-1]
         print(s.comments)
         assert "I removed a baseline" in s.comments
 

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -264,19 +264,12 @@ class TestSpectrum:
     def test_history_and_comments(self):
         s = self.ps1
         s.baseline(2, remove=True)
-        print(s.comments)
         s.add_comment("I removed a baseline")
         # This tests that the baseline command self-logged to history
         # AND that order is preserved because
         # the baseline history should be the last entry
         # print(s.history)
-        # **************************************************
-        # NOTE: This test is currently hacked to work pending
-        # merge of PR 1109. Once that is merged, this test
-        # must be updated to match the corrected output.
-        # **************************************************
-        assert "baseline(2,)" in s.history[-1]
-        print(s.comments)
+        assert "baseline(2,remove=True,)" in s.history[-1]
         assert "I removed a baseline" in s.comments
 
     def test_slice(self, tmp_path):


### PR DESCRIPTION
This PR promotes some hidden keywords in `spectra.core.baseline` to method parameters in both `spectra.core.baseline` and  `Spectrum.baseline`.   The keywords control what happens when baselining a spectrum that already has exclude regions set.  

```
exclude_action : str
How to combine the input exclude region with any existing exclude regions in the input Spectrum. Options are

- “replace” : replace the Spectrum.exclude_regions list with the input region

- “append” : append the input region to the Spectrum.exclude_regions list.

- None : Use the existing Spectrum.exclude_regions, ignoring the input region.
```

Also ``remove``, ``model``, ``fitter`` , ``clip_exclude``, and ``exclude_region_upper_bounds`` are promoted.

The behavior is documented with examples in the Quick Start guide under *Baseline Removal - Using Exclude Regions*.