### PR TITLE
1117 getspec fails

### DIFF
--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -782,6 +782,28 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             The Spectrum object representing the data row.
 
         """
+        
+        self.select(row=i,bintable=bintable,fitsindex=fitsindex)
+        # Spectrum requires certain columns, so ensure they are loaded before trying to create one.
+        _required = [
+                "CRVAL1",
+                "CRVAL2",
+                "CRVAL3",
+                "CTYPE1",
+                "CTYPE2",
+                "CTYPE3",
+                "CUNIT1",
+                "CUNIT2",
+                "CUNIT3",
+                "VELOCITY",
+                "EQUINOX",
+                "RADESYS",
+                "DATE-OBS",
+                "VELDEF",
+                "RESTFRQ",
+            ]
+        _df = self._load_full_rows_if_needed(self.selection.final, required_columns = _required)
+        self.clear_selection()
         return self._sdf[fitsindex].getspec(i, bintable, observer_location, setmask=setmask)
 
     def getrow(self, i: int, bintable: int = 0, fitsindex: int = 0) -> int:

--- a/src/dysh/fits/gbtfitsload.py
+++ b/src/dysh/fits/gbtfitsload.py
@@ -782,27 +782,27 @@ class GBTFITSLoad(SDFITSLoad, HistoricalBase):
             The Spectrum object representing the data row.
 
         """
-        
-        self.select(row=i,bintable=bintable,fitsindex=fitsindex)
+
+        self.select(row=i, bintable=bintable, fitsindex=fitsindex)
         # Spectrum requires certain columns, so ensure they are loaded before trying to create one.
         _required = [
-                "CRVAL1",
-                "CRVAL2",
-                "CRVAL3",
-                "CTYPE1",
-                "CTYPE2",
-                "CTYPE3",
-                "CUNIT1",
-                "CUNIT2",
-                "CUNIT3",
-                "VELOCITY",
-                "EQUINOX",
-                "RADESYS",
-                "DATE-OBS",
-                "VELDEF",
-                "RESTFRQ",
-            ]
-        _df = self._load_full_rows_if_needed(self.selection.final, required_columns = _required)
+            "CRVAL1",
+            "CRVAL2",
+            "CRVAL3",
+            "CTYPE1",
+            "CTYPE2",
+            "CTYPE3",
+            "CUNIT1",
+            "CUNIT2",
+            "CUNIT3",
+            "VELOCITY",
+            "EQUINOX",
+            "RADESYS",
+            "DATE-OBS",
+            "VELDEF",
+            "RESTFRQ",
+        ]
+        _df = self._load_full_rows_if_needed(self.selection.final, required_columns=_required)
         self.clear_selection()
         return self._sdf[fitsindex].getspec(i, bintable, observer_location, setmask=setmask)
 

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -101,7 +101,7 @@ class TestGBTFITSLoad:
         assert all(spec2.mask[0:101])
         assert all(spec2.mask[102:] == False)  # noqa: E712
         # regression test for #1117
-        fnm = util.get_project_testdata() / "AGBT22A_325_15" # This one has index files
+        fnm = util.get_project_testdata() / "AGBT22A_325_15"  # This one has index files
         sdf = gbtfitsload.GBTFITSLoad(fnm)
         # should not raise an excception
         s = sdf.getspec(0)

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -104,7 +104,7 @@ class TestGBTFITSLoad:
         fnm = util.get_project_testdata() / "AGBT22A_325_15" # This one has index files
         sdf = gbtfitsload.GBTFITSLoad(fnm)
         # should not raise an excception
-        s = sdf.getspec(0)
+        _s = sdf.getspec(0)
 
     def test_getspec_units(self, tmp_path):
         """

--- a/src/dysh/fits/tests/test_gbtfitsload.py
+++ b/src/dysh/fits/tests/test_gbtfitsload.py
@@ -100,6 +100,11 @@ class TestGBTFITSLoad:
         assert any(spec.mask != spec2.mask)
         assert all(spec2.mask[0:101])
         assert all(spec2.mask[102:] == False)  # noqa: E712
+        # regression test for #1117
+        fnm = util.get_project_testdata() / "AGBT22A_325_15" # This one has index files
+        sdf = gbtfitsload.GBTFITSLoad(fnm)
+        # should not raise an excception
+        s = sdf.getspec(0)
 
     def test_getspec_units(self, tmp_path):
         """


### PR DESCRIPTION
The underlying issue was that loading the index file (for speed) means certain SDFITS columns required my `Spectrum.make_spectrum` aren't present.  The solution is to call `GBTFITSLoad._load_full_rows_if_needed` before calling trying to create the `Spectrum`.

Added a regression test, too.