### PR TITLE
Fixes plotter zoom issue when changing units

### DIFF
--- a/src/dysh/plot/labgui.py
+++ b/src/dysh/plot/labgui.py
@@ -28,6 +28,7 @@ class LabGUI(BaseGUI):
             self.canvas = Canvas(plotbase.figure)
             self.canvas.manager = FigureManager(self.canvas, 0)
         plotbase.figure.canvas.header_visible = False  # Remove canvas header.
+        self.toolbar = self.canvas.manager.toolbar  # Expose the toolbar.
 
         self.button_clear = Button(
             description="Clear All Regions",

--- a/src/dysh/plot/plotbase.py
+++ b/src/dysh/plot/plotbase.py
@@ -5,6 +5,7 @@ Plot a spectrum using matplotlib
 import datetime as dt
 import os
 import sys
+from weakref import WeakKeyDictionary
 
 import astropy.units as u
 import matplotlib as mpl
@@ -68,6 +69,7 @@ class PlotBase:
     def __init__(self):
         self._init_plot()
         self._scan_numbers = None
+        self._data_limits = {}
 
     def _set_frontend(self):
         self._frontend = GUI(self)
@@ -270,3 +272,43 @@ class PlotBase:
                 button.set_visible(True)
         else:
             self.figure.savefig(file, *kwargs)
+
+    def _update_home(self, xlim: tuple[float, float], ylim: tuple[float, float]):
+        """
+        Updates the view for the "home" button.
+        This sets the "home" values to the current view,
+        it does not update the plot.
+
+        Parameters
+        ----------
+        xlim : tuple
+            x axis limits in data units.
+        ylim : tuple
+            y axis limits in data units.
+        """
+        if hasattr(self._frontend, "toolbar"):
+            # Clear current values.
+            self._frontend.toolbar._nav_stack.clear()
+            ax_view = {
+                "xlim": xlim,
+                "autoscalex_on": self.axes.get_autoscalex_on(),
+                "ylim": ylim,
+                "autoscaley_on": self.axes.get_autoscaley_on(),
+            }
+            # Push the view to the stack.
+            self._frontend.toolbar._nav_stack.push(
+                WeakKeyDictionary(
+                    {
+                        self.axes: (
+                            ax_view,
+                            # Store both the original and modified positions.
+                            (self.axes.get_position(True).frozen(), self.axes.get_position().frozen()),
+                        )
+                    }
+                )
+            )
+            self._frontend.toolbar.set_history_buttons()
+            # The default push_current uses the current view limits.
+            # That means that when using the home button, you cannot go back
+            # to the full data range if you switched units while zoomed in.
+            # self._frontend.toolbar.push_current()

--- a/src/dysh/plot/specplot.py
+++ b/src/dysh/plot/specplot.py
@@ -262,6 +262,9 @@ class SpectrumPlot(PlotBase):
                 oshow_kwargs = {}
             self.oshow(oshow, **oshow_kwargs)
 
+        # Ensure we know the data limits.
+        self._set_data_limits()
+
         self.show()
         self.figure.canvas.draw_idle()
 
@@ -549,14 +552,25 @@ class SpectrumPlot(PlotBase):
         )
         self.figure.canvas.draw_idle()
 
-    def update_limits(self):
+    def update_limits(self, visible_only: bool = True):
         """
         Recompute the data limits based on the current artists (`~matplotlib.axes.Axes.relim`),
         and then autoscale the view limits using the data limits (`~matplotlib.axes.Axes.autoscale_view`).
         """
-        self.axes.relim(visible_only=True)
+        self.axes.relim(visible_only=visible_only)
         self.axes.autoscale_view()
         self.figure.canvas.draw_idle()
+
+    def _set_data_limits(self):
+        """
+        Update the `_data_limits` dictionary to the current data ranges with margins.
+        `_data_limits` are used to set the axes limits when changing units and the
+        axes ranges of the "home" button.
+        """
+        xmargin = abs(self._sa.value[0] - self._sa.value[-1]) * self.axes.get_xmargin()
+        self._data_limits["xlim"] = (self._sa.value[0] - xmargin, self._sa.value[-1] + xmargin)
+        ymargin = abs(self._fa.value.max() - self._fa.value.min()) * self.axes.get_ymargin()
+        self._data_limits["ylim"] = (self._fa.value.min() - ymargin, self._fa.value.max() + ymargin)
 
     def set_yaxis_unit(self, yunit: str | Quantity) -> None:
         """
@@ -598,11 +612,14 @@ class SpectrumPlot(PlotBase):
         self._fa = yvals
 
         self.set_ydata(yvals, keep_unit=True)
+        self._set_data_limits()
+        self.axes.set_ylim(*self._data_limits["ylim"])
 
         self._plot_kwargs["yaxis_unit"] = yunit
         self._set_labels(**self._plot_kwargs)
 
         self.update_limits()
+        self._update_home(self._data_limits["xlim"], self._data_limits["ylim"])
 
     def set_xaxis_unit(self, xunit: str | Quantity) -> None:
         """
@@ -635,6 +652,8 @@ class SpectrumPlot(PlotBase):
             doppler_convention=self._sa.doppler_convention,
         )
         self._line.set_xdata(self._sa.value)
+        self._set_data_limits()
+        self.axes.set_xlim(*self._data_limits["xlim"])
 
         # Remove any oshows.
         # We cannot update them since we do not keep a reference to their spectra.
@@ -655,6 +674,7 @@ class SpectrumPlot(PlotBase):
         self._set_labels(**self._plot_kwargs)
 
         self.update_limits()
+        self._update_home(self._data_limits["xlim"], self._data_limits["ylim"])
 
         # Now it should be safe to add a blank span.
         if self._selector is not None:
@@ -688,6 +708,7 @@ class SpectrumPlot(PlotBase):
         self._clear_overlay_objects("lines", "oshow")
 
         self.update_limits()
+        self._update_home(self._data_limits["xlim"], self._data_limits["ylim"])
 
     def show_baseline(self, y, *args, **kwargs) -> None:
         """


### PR DESCRIPTION
If the units were changed while zoomed in, then the axes limits would not update to the new units, leaving a potentially blank plot. On top of that, the home button would preserve the coordinates at the time the toolbar was initialized. This PR fixes that by setting the axes limits after every unit change, and by updating the home button location to one compatible with the plot units.