### PR TITLE
Ensure lazy flag temporary files  are cleaned up as we go.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ We refer to this interface as the dysh shell.
 
 .. note::
 
-   For large SDFITS files (> 1 GB or so), dysh may create temporary files during certain operations to hold flag arrays.  By default these files are created in ``/tmp``. To avoid filling up ``/tmp``, you can (and should) change that default by setting ``$DYSH_SCRATCH`` or ``$TMPDIR`` environment variables to point to a directory where temporary files can be written.
+   For large SDFITS files (> 1 GB or so), dysh may create temporary files during certain operations to hold flag arrays.  By default these files are created in ``/tmp``. To avoid filling up ``/tmp``, you can (and should) change that default by setting ``$DYSH_SCRATCH`` or ``$TMPDIR`` environment variables to point to a directory where temporary files can be written.  Note these must be set before you start dysh as the values are cached by Python at startup, so ``os.putenv()`` would not have any effect..
 
 Loading Data
 ============

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,10 @@ After being installed, the ``dysh`` command will be available through the comman
 This will launch an `iPython <https://ipython.readthedocs.io/en/stable/>`_ session with some modules and classes pre-loaded (e.g., `~dysh.fits.gbtfitsload.GBTFITSLoad`), and with logging.
 We refer to this interface as the dysh shell.
 
+.. note::
+
+   For large SDFITS files (> 1 GB or so), dysh may create temporary files during certain operations to hold flag arrays.  By default these files are created in ``/tmp``. To avoid filling up ``/tmp``, you can (and should) change that default by setting ``$DYSH_SCRATCH`` or ``$TMPDIR`` environment variables to point to a directory where temporary files can be written.
+
 Loading Data
 ============
 

--- a/src/dysh/fits/lazyflag.py
+++ b/src/dysh/fits/lazyflag.py
@@ -375,11 +375,11 @@ class LazyFlagArray:
             # We put this inside to_dense instead of in the constructor to allow user to
             # change environment variable during a dysh session.
             # Note: With astropy >= 8.0, astropy.config.temporary_cache_dir() may be useful here
-            if _tmpdir := os.getenv("DYSH_SCRATCH") is not None:
+            if ( _tmpdir := os.getenv("DYSH_SCRATCH") ) is not None:
                 # XDG_CACHE_HOME will be ignored because astropy steals it. So don't even try.
                 #    _tmpdir = os.getenv("XDG_CACHE_HOME") 
             #if _tmpdir is not None:
-                tempfile.tempdir == _tmpdir
+                tempfile.tempdir = _tmpdir
             tmpdir = tempfile.gettempdir()
             logger.debug(f"LazyFlagArray.to_dense: Using temporary file directory {tmpdir}")
             try:

--- a/src/dysh/fits/lazyflag.py
+++ b/src/dysh/fits/lazyflag.py
@@ -371,7 +371,17 @@ class LazyFlagArray:
 
         if use_memmap:
             logger.debug(f"LazyFlagArray.to_dense: using memmap for {estimated_bytes / 1024**3:.1f} GB array")
+            # Look for a scratch dir so as not to fill up small /tmp filesystems.
+            # We put this inside to_dense instead of in the constructor to allow user to
+            # change environment variable during a dysh session.
+            # Note: With astropy >= 8.0, astropy.config.temporary_cache_dir() may be useful here
+            if _tmpdir := os.getenv("DYSH_SCRATCH") is not None:
+                # XDG_CACHE_HOME will be ignored because astropy steals it. So don't even try.
+                #    _tmpdir = os.getenv("XDG_CACHE_HOME") 
+            #if _tmpdir is not None:
+                tempfile.tempdir == _tmpdir
             tmpdir = tempfile.gettempdir()
+            logger.debug(f"LazyFlagArray.to_dense: Using temporary file directory {tmpdir}")
             try:
                 free_bytes = shutil.disk_usage(tmpdir).free
             except OSError:
@@ -404,7 +414,9 @@ class LazyFlagArray:
         # Apply sparse overlay
         for row_idx, row_mask in self._modified.items():
             result[row_idx] |= row_mask
-
+        # make weakref finalizer so that temporary dense arrays are removed from the filesystem when
+        # there are no longer any strong references.
+        self._mmap_ref = weakref.finalize(result,self.cleanup)
         return result
 
     def rows_as_uint8(self, rows):

--- a/src/dysh/fits/lazyflag.py
+++ b/src/dysh/fits/lazyflag.py
@@ -375,10 +375,10 @@ class LazyFlagArray:
             # We put this inside to_dense instead of in the constructor to allow user to
             # change environment variable during a dysh session.
             # Note: With astropy >= 8.0, astropy.config.temporary_cache_dir() may be useful here
-            if ( _tmpdir := os.getenv("DYSH_SCRATCH") ) is not None:
+            if (_tmpdir := os.getenv("DYSH_SCRATCH")) is not None:
                 # XDG_CACHE_HOME will be ignored because astropy steals it. So don't even try.
-                #    _tmpdir = os.getenv("XDG_CACHE_HOME") 
-            #if _tmpdir is not None:
+                #    _tmpdir = os.getenv("XDG_CACHE_HOME")
+                # if _tmpdir is not None:
                 tempfile.tempdir = _tmpdir
             tmpdir = tempfile.gettempdir()
             logger.debug(f"LazyFlagArray.to_dense: Using temporary file directory {tmpdir}")
@@ -416,7 +416,7 @@ class LazyFlagArray:
             result[row_idx] |= row_mask
         # make weakref finalizer so that temporary dense arrays are removed from the filesystem when
         # there are no longer any strong references.
-        self._mmap_ref = weakref.finalize(result,self.cleanup)
+        self._mmap_ref = weakref.finalize(result, self.cleanup)
         return result
 
     def rows_as_uint8(self, rows):

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -3,6 +3,7 @@
 import gc
 import os
 import tempfile
+import time
 
 import numpy as np
 import pytest
@@ -410,6 +411,13 @@ class TestLazyFlagCleanup:
         path = arr._tempfiles[0]
         assert os.path.exists(path)
         del dense
-        gc.collect()
+        # On Windows, the OS file handle backing the memmap is not guaranteed to be
+        # released the instant the object is destroyed, even after gc.collect(), so
+        # poll briefly rather than asserting immediately.
+        for _ in range(20):
+            gc.collect()
+            if not os.path.exists(path):
+                break
+            time.sleep(0.1)
         assert not os.path.exists(path)
         assert arr is not None  # keep arr alive past the assertion above

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -2,8 +2,8 @@
 
 import gc
 import os
+import sys
 import tempfile
-import time
 
 import numpy as np
 import pytest
@@ -403,6 +403,10 @@ class TestLazyFlagCleanup:
             del dense
             arr.cleanup()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows does not release the memmap's file handle synchronously on refcount drop",
+    )
     def test_to_dense_finalize_cleans_up_without_explicit_cleanup(self):
         """The weakref.finalize tied to the dense array removes the temp file on its own,
         without calling arr.cleanup() or deleting arr."""
@@ -411,13 +415,6 @@ class TestLazyFlagCleanup:
         path = arr._tempfiles[0]
         assert os.path.exists(path)
         del dense
-        # On Windows, the OS file handle backing the memmap is not guaranteed to be
-        # released the instant the object is destroyed, even after gc.collect(), so
-        # poll briefly rather than asserting immediately.
-        for _ in range(20):
-            gc.collect()
-            if not os.path.exists(path):
-                break
-            time.sleep(0.1)
+        gc.collect()
         assert not os.path.exists(path)
         assert arr is not None  # keep arr alive past the assertion above

--- a/src/dysh/fits/tests/test_lazyflag.py
+++ b/src/dysh/fits/tests/test_lazyflag.py
@@ -1,6 +1,8 @@
 """Tests for LazyFlagArray and LazyFlagContainer."""
 
+import gc
 import os
+import tempfile
 
 import numpy as np
 import pytest
@@ -357,3 +359,57 @@ class TestLazyFlagCleanup:
         del dense
         arr.cleanup()
         assert any("free in" in rec.message and "memmap" in rec.message for rec in caplog.records)
+
+    def test_to_dense_uses_dysh_scratch(self, tmp_path, monkeypatch):
+        """to_dense() places its temp file under $DYSH_SCRATCH when set."""
+        monkeypatch.setenv("DYSH_SCRATCH", str(tmp_path))
+        monkeypatch.setattr(tempfile, "tempdir", None)
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        dense = arr.to_dense()
+        try:
+            assert os.path.dirname(arr._tempfiles[0]) == str(tmp_path)
+        finally:
+            del dense
+            arr.cleanup()
+
+    def test_to_dense_uses_tmpdir_env(self, tmp_path, monkeypatch):
+        """to_dense() places its temp file under $TMPDIR when DYSH_SCRATCH is unset."""
+        monkeypatch.delenv("DYSH_SCRATCH", raising=False)
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setattr(tempfile, "tempdir", None)
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        dense = arr.to_dense()
+        try:
+            assert os.path.dirname(arr._tempfiles[0]) == str(tmp_path)
+        finally:
+            del dense
+            arr.cleanup()
+
+    def test_dysh_scratch_takes_precedence_over_tmpdir(self, tmp_path, monkeypatch):
+        """DYSH_SCRATCH wins over TMPDIR when both are set."""
+        scratch_dir = tmp_path / "scratch"
+        scratch_dir.mkdir()
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        monkeypatch.setenv("DYSH_SCRATCH", str(scratch_dir))
+        monkeypatch.setenv("TMPDIR", str(other_dir))
+        monkeypatch.setattr(tempfile, "tempdir", None)
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        dense = arr.to_dense()
+        try:
+            assert os.path.dirname(arr._tempfiles[0]) == str(scratch_dir)
+        finally:
+            del dense
+            arr.cleanup()
+
+    def test_to_dense_finalize_cleans_up_without_explicit_cleanup(self):
+        """The weakref.finalize tied to the dense array removes the temp file on its own,
+        without calling arr.cleanup() or deleting arr."""
+        arr = LazyFlagArray(10, 100, memmap_threshold=0)
+        dense = arr.to_dense()
+        path = arr._tempfiles[0]
+        assert os.path.exists(path)
+        del dense
+        gc.collect()
+        assert not os.path.exists(path)
+        assert arr is not None  # keep arr alive past the assertion above


### PR DESCRIPTION
This fixes #1125 
1.  Add `weakref.finalize` in `LazyFlags.to_dense()` so that memory mapped files are removed when there are no longer strong references to the arrays they underlie.
2. Use $DYSH_SCRATCH as the temporary directory if it is set. 
3. Add tests that all this works as advertised.  Windows OS is skipped for one test because of delay in actually removing files on Windows.
4. Add a Note to the quick reference guide about the need for DYSH_SCRATCH (or TMPDIR)