### PR TITLE
Exclude _build from Sphinx source discovery (#830)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = ["examples/output"]
+exclude_patterns = ["examples/output", "_build", "**.ipynb_checkpoints"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"


### PR DESCRIPTION
## Summary
- Fixes #830: `make html` kept nesting `_build/jupyter_execute/_build/...` directories deeper on every incremental build.
- Root cause: `BUILDDIR` (`_build`) lives inside `SOURCEDIR` (`docs/source`) but wasn't in `exclude_patterns`, so myst-nb re-discovered and re-executed notebooks left behind in the previous `_build` output.
- Adds `"_build"` and `"**.ipynb_checkpoints"` to `exclude_patterns` in `docs/source/conf.py`.

## Test plan
- [x] `rm -rf docs/source/_build` then ran `make html` twice in a row without `make clean`
- [x] Confirmed no nested `_build/jupyter_execute/_build/...` directories appeared after the second build
- [x] `uv run ruff check docs/source/conf.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)