### PR TITLE
1151 spectrumquery lines ignores chemical name

### DIFF
--- a/src/dysh/spectra/spectrum.py
+++ b/src/dysh/spectra/spectrum.py
@@ -2152,6 +2152,7 @@ class Spectrum(Spectrum1D, HistoricalBase):
         return SpectralLineSearch.query_lines(
             min_frequency=minf,
             max_frequency=maxf,
+            chemical_name=chemical_name,
             intensity_lower_limit=intensity_lower_limit,
             cat=cat,
             columns=columns,

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1277,6 +1277,12 @@ class TestSpectrum:
         )
         assert np.all(np.isclose(tr["obs_frequency"].data - freq, 0, atol=1e-7))
 
+        # regression for #1151
+        t = f.query_lines(cat='gbtlines')
+        t2 = f.query_lines(cat='gbtlines',chemical_name='Atomic Hydrogen')
+        assert not np.all(t == t2)
+        assert len(t2) == 1
+
     def test_set_rest_value(self):
         """Test that setting rest_value works."""
         s1 = Spectrum.fake_spectrum()

--- a/src/dysh/spectra/tests/test_spectrum.py
+++ b/src/dysh/spectra/tests/test_spectrum.py
@@ -1278,8 +1278,8 @@ class TestSpectrum:
         assert np.all(np.isclose(tr["obs_frequency"].data - freq, 0, atol=1e-7))
 
         # regression for #1151
-        t = f.query_lines(cat='gbtlines')
-        t2 = f.query_lines(cat='gbtlines',chemical_name='Atomic Hydrogen')
+        t = f.query_lines(cat="gbtlines")
+        t2 = f.query_lines(cat="gbtlines", chemical_name="Atomic Hydrogen")
         assert not np.all(t == t2)
         assert len(t2) == 1
 


### PR DESCRIPTION
Simple fix to add missing passed parameter `chemical_name`